### PR TITLE
Add Url property to Page struct

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -186,7 +186,7 @@ func TestDatabaseClient(t *testing.T) {
 								DatabaseID: "some_id",
 							},
 							Archived: false,
-							Url:      "some_url",
+							URL:      "some_url",
 						},
 					},
 					HasMore:    false,

--- a/database_test.go
+++ b/database_test.go
@@ -186,6 +186,7 @@ func TestDatabaseClient(t *testing.T) {
 								DatabaseID: "some_id",
 							},
 							Archived: false,
+							Url:      "some_url",
 						},
 					},
 					HasMore:    false,

--- a/page.go
+++ b/page.go
@@ -66,7 +66,7 @@ type Page struct {
 	Archived       bool       `json:"archived"`
 	Properties     Properties `json:"properties"`
 	Parent         Parent     `json:"parent"`
-	Url            Url        `json:"url"`
+	URL            string     `json:"url"`
 }
 
 func (p *Page) GetObject() ObjectType {
@@ -86,8 +86,6 @@ type PageCreateRequest struct {
 	Properties Properties `json:"properties"`
 	Children   []Block    `json:"children,omitempty"`
 }
-
-type Url string
 
 func handlePageResponse(res *http.Response) (*Page, error) {
 	var response Page

--- a/page.go
+++ b/page.go
@@ -66,6 +66,7 @@ type Page struct {
 	Archived       bool       `json:"archived"`
 	Properties     Properties `json:"properties"`
 	Parent         Parent     `json:"parent"`
+	Url            Url        `json:"url"`
 }
 
 func (p *Page) GetObject() ObjectType {
@@ -85,6 +86,8 @@ type PageCreateRequest struct {
 	Properties Properties `json:"properties"`
 	Children   []Block    `json:"children,omitempty"`
 }
+
+type Url string
 
 func handlePageResponse(res *http.Response) (*Page, error) {
 	var response Page

--- a/page_test.go
+++ b/page_test.go
@@ -40,7 +40,7 @@ func TestPageClient(t *testing.T) {
 						DatabaseID: "some_id",
 					},
 					Archived: false,
-					Url:      "some_url",
+					URL:      "some_url",
 				},
 			},
 			{
@@ -122,7 +122,7 @@ func TestPageClient(t *testing.T) {
 						DatabaseID: "some_id",
 					},
 					Archived: false,
-					Url:      "some_url",
+					URL:      "some_url",
 				},
 			},
 		}
@@ -184,7 +184,7 @@ func TestPageClient(t *testing.T) {
 						DatabaseID: "some_id",
 					},
 					Archived: false,
-					Url:      "some_url",
+					URL:      "some_url",
 				},
 			},
 		}

--- a/page_test.go
+++ b/page_test.go
@@ -40,6 +40,7 @@ func TestPageClient(t *testing.T) {
 						DatabaseID: "some_id",
 					},
 					Archived: false,
+					Url:      "some_url",
 				},
 			},
 			{
@@ -121,6 +122,7 @@ func TestPageClient(t *testing.T) {
 						DatabaseID: "some_id",
 					},
 					Archived: false,
+					Url:      "some_url",
 				},
 			},
 		}
@@ -182,6 +184,7 @@ func TestPageClient(t *testing.T) {
 						DatabaseID: "some_id",
 					},
 					Archived: false,
+					Url:      "some_url",
 				},
 			},
 		}

--- a/testdata/database_query.json
+++ b/testdata/database_query.json
@@ -11,6 +11,7 @@
         "database_id": "some_id"
       },
       "archived": false,
+      "url": "some_url",
       "properties": {
         "Tags": {
           "id": ";s|V",

--- a/testdata/page_create.json
+++ b/testdata/page_create.json
@@ -8,6 +8,7 @@
     "database_id": "some_id"
   },
   "archived": false,
+  "url": "some_url",
   "properties": {
     "Tags": {
       "id": ";s|V",

--- a/testdata/page_get.json
+++ b/testdata/page_get.json
@@ -8,6 +8,7 @@
     "database_id": "some_id"
   },
   "archived": false,
+  "url": "some_url",
   "properties": {
     "Tags": {
       "id": ";s|V",

--- a/testdata/page_update.json
+++ b/testdata/page_update.json
@@ -8,6 +8,7 @@
     "database_id": "some_id"
   },
   "archived": false,
+  "url": "some_url",
   "properties": {
     "Tags": {
       "id": ";s|V",


### PR DESCRIPTION
Hey there, 
Notion has added a `url` property to the [Page object](https://developers.notion.com/reference/page) and I tried to add it to the Page struct.

I'm very new to Go so please tell me if there's any mistakes.