### PR TITLE
Add `archived` parameter

### DIFF
--- a/page.go
+++ b/page.go
@@ -46,6 +46,7 @@ func (pc *PageClient) Create(ctx context.Context, requestBody *PageCreateRequest
 
 type PageUpdateRequest struct {
 	Properties Properties `json:"properties"`
+	Archived   bool       `json:"archived"`
 }
 
 // Update https://developers.notion.com/reference/patch-page


### PR DESCRIPTION
### Description
The `archived` parameter can now be used to delete a page in the Update page API, so I added this.

https://developers.notion.com/reference/patch-page