### PR TITLE
Add support for file-based blocks and embeds/bookmarks

### DIFF
--- a/block.go
+++ b/block.go
@@ -273,6 +273,128 @@ func (b ChildPageBlock) GetType() BlockType {
 	return b.Type
 }
 
+type EmbedBlock struct {
+	Object         ObjectType `json:"object"`
+	ID             BlockID    `json:"id,omitempty"`
+	Type           BlockType  `json:"type"`
+	CreatedTime    *time.Time `json:"created_time,omitempty"`
+	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	HasChildren    bool       `json:"has_children,omitempty"`
+	Embed          Embed      `json:"embed,omitempty"`
+}
+
+func (b EmbedBlock) GetType() BlockType {
+	return b.Type
+}
+
+type Embed struct {
+	Caption []RichText `json:"caption,omitempty"`
+	URL     string     `json:"url"`
+}
+
+type ImageBlock struct {
+	Object         ObjectType `json:"object"`
+	ID             BlockID    `json:"id,omitempty"`
+	Type           BlockType  `json:"type"`
+	CreatedTime    *time.Time `json:"created_time,omitempty"`
+	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	HasChildren    bool       `json:"has_children,omitempty"`
+	Image          Image      `json:"image,omitempty"`
+}
+
+func (b ImageBlock) GetType() BlockType {
+	return b.Type
+}
+
+type Image struct {
+	Caption  []RichText `json:"caption,omitempty"`
+	Type     FileType   `json:"type,omitempty"`
+	File     FileObject `json:"file,omitempty"`
+	External FileObject `json:"external,omitempty"`
+}
+
+type VideoBlock struct {
+	Object         ObjectType `json:"object"`
+	ID             BlockID    `json:"id,omitempty"`
+	Type           BlockType  `json:"type"`
+	CreatedTime    *time.Time `json:"created_time,omitempty"`
+	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	HasChildren    bool       `json:"has_children,omitempty"`
+	Video          Video      `json:"video,omitempty"`
+}
+
+func (b VideoBlock) GetType() BlockType {
+	return b.Type
+}
+
+type Video struct {
+	Caption  []RichText `json:"caption,omitempty"`
+	Type     FileType   `json:"type,omitempty"`
+	File     FileObject `json:"file,omitempty"`
+	External FileObject `json:"external,omitempty"`
+}
+
+type FileBlock struct {
+	Object         ObjectType `json:"object"`
+	ID             BlockID    `json:"id,omitempty"`
+	Type           BlockType  `json:"type"`
+	CreatedTime    *time.Time `json:"created_time,omitempty"`
+	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	HasChildren    bool       `json:"has_children,omitempty"`
+	File           BlockFile  `json:"file,omitempty"`
+}
+
+func (b FileBlock) GetType() BlockType {
+	return b.Type
+}
+
+type BlockFile struct {
+	Caption  []RichText `json:"caption,omitempty"`
+	Type     FileType   `json:"type,omitempty"`
+	File     FileObject `json:"file,omitempty"`
+	External FileObject `json:"external,omitempty"`
+}
+
+type PdfBlock struct {
+	Object         ObjectType `json:"object"`
+	ID             BlockID    `json:"id,omitempty"`
+	Type           BlockType  `json:"type"`
+	CreatedTime    *time.Time `json:"created_time,omitempty"`
+	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	HasChildren    bool       `json:"has_children,omitempty"`
+	Pdf            Pdf        `json:"pdf,omitempty"`
+}
+
+func (b PdfBlock) GetType() BlockType {
+	return b.Type
+}
+
+type Pdf struct {
+	Caption  []RichText `json:"caption,omitempty"`
+	Type     FileType   `json:"type,omitempty"`
+	File     FileObject `json:"file,omitempty"`
+	External FileObject `json:"external,omitempty"`
+}
+
+type BookmarkBlock struct {
+	Object         ObjectType `json:"object"`
+	ID             BlockID    `json:"id,omitempty"`
+	Type           BlockType  `json:"type"`
+	CreatedTime    *time.Time `json:"created_time,omitempty"`
+	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	HasChildren    bool       `json:"has_children,omitempty"`
+	Bookmark       Bookmark   `json:"bookmark,omitempty"`
+}
+
+func (b BookmarkBlock) GetType() BlockType {
+	return b.Type
+}
+
+type Bookmark struct {
+	Caption []RichText `json:"caption,omitempty"`
+	URL     string     `json:"url,omitempty"`
+}
+
 func decodeBlock(raw map[string]interface{}) (Block, error) {
 	var b Block
 	switch BlockType(raw["type"].(string)) {
@@ -294,6 +416,18 @@ func decodeBlock(raw map[string]interface{}) (Block, error) {
 		b = &ToggleBlock{}
 	case BlockTypeChildPage:
 		b = &ChildPageBlock{}
+	case BlockTypeEmbed:
+		b = &EmbedBlock{}
+	case BlockTypeImage:
+		b = &ImageBlock{}
+	case BlockTypeVideo:
+		b = &VideoBlock{}
+	case BlockTypeFile:
+		b = &FileBlock{}
+	case BlockTypePdf:
+		b = &PdfBlock{}
+	case BlockTypeBookmark:
+		b = &BookmarkBlock{}
 	default:
 		return nil, fmt.Errorf("unsupported block type: %s", raw["type"].(string))
 	}
@@ -315,4 +449,10 @@ type BlockUpdateRequest struct {
 	NumberedListItem *ListItem  `json:"numbered_list_item,omitempty"`
 	ToDo             *ToDo      `json:"to_do,omitempty"`
 	Toggle           *Toggle    `json:"toggle,omtiempty"`
+	Embed            *Embed     `json:"embed,omitempty"`
+	Image            *Image     `json:"image,omitempty"`
+	Video            *Video     `json:"video,omitempty"`
+	File             *BlockFile `json:"file,omitempty"`
+	Pdf              *Pdf       `json:"pdf,omitempty"`
+	Bookmark         *Bookmark  `json:"bookmark,omitempty"`
 }

--- a/block.go
+++ b/block.go
@@ -280,7 +280,7 @@ type EmbedBlock struct {
 	CreatedTime    *time.Time `json:"created_time,omitempty"`
 	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
 	HasChildren    bool       `json:"has_children,omitempty"`
-	Embed          Embed      `json:"embed,omitempty"`
+	Embed          Embed      `json:"embed"`
 }
 
 func (b EmbedBlock) GetType() BlockType {
@@ -299,7 +299,7 @@ type ImageBlock struct {
 	CreatedTime    *time.Time `json:"created_time,omitempty"`
 	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
 	HasChildren    bool       `json:"has_children,omitempty"`
-	Image          Image      `json:"image,omitempty"`
+	Image          Image      `json:"image"`
 }
 
 func (b ImageBlock) GetType() BlockType {
@@ -308,9 +308,9 @@ func (b ImageBlock) GetType() BlockType {
 
 type Image struct {
 	Caption  []RichText `json:"caption,omitempty"`
-	Type     FileType   `json:"type,omitempty"`
-	File     FileObject `json:"file,omitempty"`
-	External FileObject `json:"external,omitempty"`
+	Type     FileType   `json:"type"`
+	File     *FileObject `json:"file,omitempty"`
+	External *FileObject `json:"external,omitempty"`
 }
 
 type VideoBlock struct {
@@ -320,7 +320,7 @@ type VideoBlock struct {
 	CreatedTime    *time.Time `json:"created_time,omitempty"`
 	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
 	HasChildren    bool       `json:"has_children,omitempty"`
-	Video          Video      `json:"video,omitempty"`
+	Video          Video      `json:"video"`
 }
 
 func (b VideoBlock) GetType() BlockType {
@@ -329,9 +329,9 @@ func (b VideoBlock) GetType() BlockType {
 
 type Video struct {
 	Caption  []RichText `json:"caption,omitempty"`
-	Type     FileType   `json:"type,omitempty"`
-	File     FileObject `json:"file,omitempty"`
-	External FileObject `json:"external,omitempty"`
+	Type     FileType   `json:"type"`
+	File     *FileObject `json:"file,omitempty"`
+	External *FileObject `json:"external,omitempty"`
 }
 
 type FileBlock struct {
@@ -341,7 +341,7 @@ type FileBlock struct {
 	CreatedTime    *time.Time `json:"created_time,omitempty"`
 	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
 	HasChildren    bool       `json:"has_children,omitempty"`
-	File           BlockFile  `json:"file,omitempty"`
+	File           BlockFile  `json:"file"`
 }
 
 func (b FileBlock) GetType() BlockType {
@@ -350,9 +350,9 @@ func (b FileBlock) GetType() BlockType {
 
 type BlockFile struct {
 	Caption  []RichText `json:"caption,omitempty"`
-	Type     FileType   `json:"type,omitempty"`
-	File     FileObject `json:"file,omitempty"`
-	External FileObject `json:"external,omitempty"`
+	Type     FileType   `json:"type"`
+	File     *FileObject `json:"file,omitempty"`
+	External *FileObject `json:"external,omitempty"`
 }
 
 type PdfBlock struct {
@@ -362,7 +362,7 @@ type PdfBlock struct {
 	CreatedTime    *time.Time `json:"created_time,omitempty"`
 	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
 	HasChildren    bool       `json:"has_children,omitempty"`
-	Pdf            Pdf        `json:"pdf,omitempty"`
+	Pdf            Pdf        `json:"pdf"`
 }
 
 func (b PdfBlock) GetType() BlockType {
@@ -371,9 +371,9 @@ func (b PdfBlock) GetType() BlockType {
 
 type Pdf struct {
 	Caption  []RichText `json:"caption,omitempty"`
-	Type     FileType   `json:"type,omitempty"`
-	File     FileObject `json:"file,omitempty"`
-	External FileObject `json:"external,omitempty"`
+	Type     FileType   `json:"type"`
+	File     *FileObject `json:"file,omitempty"`
+	External *FileObject `json:"external,omitempty"`
 }
 
 type BookmarkBlock struct {
@@ -383,7 +383,7 @@ type BookmarkBlock struct {
 	CreatedTime    *time.Time `json:"created_time,omitempty"`
 	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
 	HasChildren    bool       `json:"has_children,omitempty"`
-	Bookmark       Bookmark   `json:"bookmark,omitempty"`
+	Bookmark       Bookmark   `json:"bookmark"`
 }
 
 func (b BookmarkBlock) GetType() BlockType {
@@ -392,7 +392,7 @@ func (b BookmarkBlock) GetType() BlockType {
 
 type Bookmark struct {
 	Caption []RichText `json:"caption,omitempty"`
-	URL     string     `json:"url,omitempty"`
+	URL     string     `json:"url"`
 }
 
 func decodeBlock(raw map[string]interface{}) (Block, error) {

--- a/const.go
+++ b/const.go
@@ -183,10 +183,22 @@ const (
 	BlockTypeBulletedListItem BlockType = "bulleted_list_item"
 	BlockTypeNumberedListItem BlockType = "numbered_list_item"
 
-	BlockTypeToDo        BlockType = "to_do"
-	BlockTypeToggle      BlockType = "toggle"
-	BlockTypeChildPage   BlockType = "child_page"
+	BlockTypeToDo      BlockType = "to_do"
+	BlockTypeToggle    BlockType = "toggle"
+	BlockTypeChildPage BlockType = "child_page"
+
+	BlockTypeEmbed       BlockType = "embed"
+	BlockTypeImage       BlockType = "image"
+	BlockTypeVideo       BlockType = "video"
+	BlockTypeFile        BlockType = "file"
+	BlockTypePdf         BlockType = "pdf"
+	BlockTypeBookmark    BlockType = "bookmark"
 	BlockTypeUnsupported BlockType = "unsupported"
+)
+
+const (
+	FileTypeFile     FileType = "file"
+	FileTypeExternal FileType = "external"
 )
 
 const (

--- a/object.go
+++ b/object.go
@@ -104,8 +104,15 @@ func (d *Date) UnmarshalText(data []byte) error {
 	return nil
 }
 
+type FileType string
+
 type File struct {
 	Name string `json:"name"`
+}
+
+type FileObject struct {
+	URL string `json:"url,omitempty"`
+	ExpiryTime *time.Time `json:"expiry_time,omitempty"`
 }
 
 type PropertyID string


### PR DESCRIPTION
Hi. Random PR here, but I am needing support for these block types for my integration that I am working on.

This PR should bring your codebase in line with the documentation for blocks.

The only real issue I had when doing this is what to call the File object that is attached to the blocks, so, I went with `BlockFile` but, obviously, that breaks naming conventions. If you have a better suggestion, or if you wanted to rename the File struct that is used by the Property, I'll leave that up to you.

Please let me know if there is anything else that I can do to help. :-D