### PR TITLE
fix RichText definition 

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -39,7 +39,7 @@ func TestDatabaseClient(t *testing.T) {
 					Title: []notionapi.RichText{
 						{
 							Type:        notionapi.ObjectTypeText,
-							Text:        notionapi.Text{Content: "Test Database", Link: ""},
+							Text:        notionapi.Text{Content: "Test Database"},
 							Annotations: &notionapi.Annotations{Color: "default"},
 							PlainText:   "Test Database",
 							Href:        "",

--- a/object.go
+++ b/object.go
@@ -44,7 +44,11 @@ type RichText struct {
 
 type Text struct {
 	Content string `json:"content"`
-	Link    string `json:"link,omitempty"`
+	Link    Link   `json:"link,omitempty"`
+}
+
+type Link struct {
+	Url string `json:"url,omitempty"`
 }
 
 type Annotations struct {
@@ -111,7 +115,7 @@ type File struct {
 }
 
 type FileObject struct {
-	URL string `json:"url,omitempty"`
+	URL        string     `json:"url,omitempty"`
 	ExpiryTime *time.Time `json:"expiry_time,omitempty"`
 }
 

--- a/object.go
+++ b/object.go
@@ -44,7 +44,7 @@ type RichText struct {
 
 type Text struct {
 	Content string `json:"content"`
-	Link    Link   `json:"link,omitempty"`
+	Link    *Link  `json:"link,omitempty"`
 }
 
 type Link struct {

--- a/page_test.go
+++ b/page_test.go
@@ -3,11 +3,12 @@ package notionapi_test
 import (
 	"context"
 	"encoding/json"
-	"github.com/jomei/notionapi"
 	"net/http"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/jomei/notionapi"
 )
 
 func TestPageClient(t *testing.T) {
@@ -340,7 +341,9 @@ func TestPageCreateRequest_MarshallJSON(t *testing.T) {
 								{
 									Text: notionapi.Text{
 										Content: "Lacinato",
-										Link:    "some_url",
+										Link: &notionapi.Link{
+											Url: "some_url",
+										},
 									},
 								},
 							},
@@ -349,7 +352,7 @@ func TestPageCreateRequest_MarshallJSON(t *testing.T) {
 					},
 				},
 			},
-			want: []byte(`{"parent":{"database_id":"some_id"},"properties":{"Link":{"url":"some_url"},"Name":{"title":[{"text":{"content":"New Media Article"}}]},"Publishing/Release Date":{"date":{"start":"2020-12-08T12:00:00Z","end":null}},"Read":{"checkbox":false},"Summary":{"text":[{"type":"text","text":{"content":"Some content"},"annotations":{"bold":true,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"blue"},"plain_text":"Some content"}]},"Type":{"select":{"id":"some_id","name":"Article","color":"default"}}},"children":[{"object":"block","type":"heading_2","heading_2":{"text":[{"type":"text","text":{"content":"Lacinato"}}]}},{"object":"block","type":"paragraph","paragraph":{"text":[{"text":{"content":"Lacinato","link":"some_url"}}]}}]}`),
+			want: []byte(`{"parent":{"database_id":"some_id"},"properties":{"Link":{"url":"some_url"},"Name":{"title":[{"text":{"content":"New Media Article"}}]},"Publishing/Release Date":{"date":{"start":"2020-12-08T12:00:00Z","end":null}},"Read":{"checkbox":false},"Summary":{"text":[{"type":"text","text":{"content":"Some content"},"annotations":{"bold":true,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"blue"},"plain_text":"Some content"}]},"Type":{"select":{"id":"some_id","name":"Article","color":"default"}}},"children":[{"object":"block","type":"heading_2","heading_2":{"text":[{"type":"text","text":{"content":"Lacinato"}}]}},{"object":"block","type":"paragraph","paragraph":{"text":[{"text":{"content":"Lacinato","link":{"url":"some_url"}}}]}}]}`),
 		},
 	}
 


### PR DESCRIPTION
According to the notion js definition for RichText, we have:

```
type TextRequest = string

type RichTextItemRequest =
  | {
      text: { content: string; link?: { url: TextRequest } | null }
      type?: "text"
```
from: https://raw.githubusercontent.com/makenotion/notion-sdk-js/main/src/api-endpoints.ts

but the definition in the current implementation was that the `Link` was a string instead of an object containing a URL.

As an example, I have a page with:
```
        "text": {
          "content": "Gastbsy",
          "link": {
            "url": "https://www.gatsbyjs.com/"
          }
```

This PR changes the type - and I was able to confirm that it is working for my notion page.

PS: my vscode does some formatting automatically. It also caught a typo (`omtiempty`)
