### PR TITLE
add parsing of child_database

### DIFF
--- a/block.go
+++ b/block.go
@@ -307,8 +307,8 @@ func (b ImageBlock) GetType() BlockType {
 }
 
 type Image struct {
-	Caption  []RichText `json:"caption,omitempty"`
-	Type     FileType   `json:"type"`
+	Caption  []RichText  `json:"caption,omitempty"`
+	Type     FileType    `json:"type"`
 	File     *FileObject `json:"file,omitempty"`
 	External *FileObject `json:"external,omitempty"`
 }
@@ -346,8 +346,8 @@ func (b VideoBlock) GetType() BlockType {
 }
 
 type Video struct {
-	Caption  []RichText `json:"caption,omitempty"`
-	Type     FileType   `json:"type"`
+	Caption  []RichText  `json:"caption,omitempty"`
+	Type     FileType    `json:"type"`
 	File     *FileObject `json:"file,omitempty"`
 	External *FileObject `json:"external,omitempty"`
 }
@@ -367,8 +367,8 @@ func (b FileBlock) GetType() BlockType {
 }
 
 type BlockFile struct {
-	Caption  []RichText `json:"caption,omitempty"`
-	Type     FileType   `json:"type"`
+	Caption  []RichText  `json:"caption,omitempty"`
+	Type     FileType    `json:"type"`
 	File     *FileObject `json:"file,omitempty"`
 	External *FileObject `json:"external,omitempty"`
 }
@@ -388,8 +388,8 @@ func (b PdfBlock) GetType() BlockType {
 }
 
 type Pdf struct {
-	Caption  []RichText `json:"caption,omitempty"`
-	Type     FileType   `json:"type"`
+	Caption  []RichText  `json:"caption,omitempty"`
+	Type     FileType    `json:"type"`
 	File     *FileObject `json:"file,omitempty"`
 	External *FileObject `json:"external,omitempty"`
 }
@@ -411,6 +411,21 @@ func (b BookmarkBlock) GetType() BlockType {
 type Bookmark struct {
 	Caption []RichText `json:"caption,omitempty"`
 	URL     string     `json:"url"`
+}
+
+type ChildDatabaseBlock struct {
+	Object         ObjectType `json:"object"`
+	ID             BlockID    `json:"id,omitempty"`
+	Type           BlockType  `json:"type"`
+	CreatedTime    *time.Time `json:"created_time,omitempty"`
+	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	ChildDatabase  struct {
+		Title string `json:"title"`
+	} `json:"child_database"`
+}
+
+func (b ChildDatabaseBlock) GetType() BlockType {
+	return b.Type
 }
 
 func decodeBlock(raw map[string]interface{}) (Block, error) {
@@ -448,6 +463,8 @@ func decodeBlock(raw map[string]interface{}) (Block, error) {
 		b = &PdfBlock{}
 	case BlockTypeBookmark:
 		b = &BookmarkBlock{}
+	case BlockTypeChildDatabase:
+		b = &ChildDatabaseBlock{}
 	default:
 		return nil, fmt.Errorf("unsupported block type: %s", raw["type"].(string))
 	}
@@ -468,7 +485,7 @@ type BlockUpdateRequest struct {
 	BulletedListItem *ListItem  `json:"bulleted_list_item,omitempty"`
 	NumberedListItem *ListItem  `json:"numbered_list_item,omitempty"`
 	ToDo             *ToDo      `json:"to_do,omitempty"`
-	Toggle           *Toggle    `json:"toggle,omtiempty"`
+	Toggle           *Toggle    `json:"toggle,omitempty"`
 	Embed            *Embed     `json:"embed,omitempty"`
 	Image            *Image     `json:"image,omitempty"`
 	Video            *Video     `json:"video,omitempty"`

--- a/const.go
+++ b/const.go
@@ -183,9 +183,10 @@ const (
 	BlockTypeBulletedListItem BlockType = "bulleted_list_item"
 	BlockTypeNumberedListItem BlockType = "numbered_list_item"
 
-	BlockTypeToDo      BlockType = "to_do"
-	BlockTypeToggle    BlockType = "toggle"
-	BlockTypeChildPage BlockType = "child_page"
+	BlockTypeToDo          BlockType = "to_do"
+	BlockTypeToggle        BlockType = "toggle"
+	BlockTypeChildPage     BlockType = "child_page"
+	BlockTypeChildDatabase BlockType = "child_database"
 
 	BlockTypeEmbed       BlockType = "embed"
 	BlockTypeImage       BlockType = "image"


### PR DESCRIPTION
add support for child_database according to spec:
https://raw.githubusercontent.com/makenotion/notion-sdk-js/main/src/api-endpoints.ts

```
{
      type: "child_database"
      child_database: { title: string }
      object: "block"
      id: string
      created_time: string
      last_edited_time: string
      has_children: boolean
      archived: boolean
    }
```