### PR TITLE
Added some unsupported block types

### DIFF
--- a/block.go
+++ b/block.go
@@ -409,8 +409,8 @@ type LinkToPageBlock struct {
 }
 
 type LinkToPage struct {
-	Type   string `json:"type"`
-	PageID string `json:"page_id"`
+	Type   BlockType `json:"type"`
+	PageID PageID    `json:"page_id"`
 }
 
 type TemplateBlock struct {
@@ -425,15 +425,17 @@ type Template struct {
 
 type SyncedBlock struct {
 	BasicBlock
-	Synced Synced `json:"synced_block"`
+	SyncedBlock Synced `json:"synced_block"`
 }
 
 type Synced struct {
 	// SyncedFrom is nil for the original block.
-	SyncedFrom *struct {
-		BlockID string `json:"original_synced_block_id"`
-	} `json:"synced_from"`
-	Children []Block `json:"children,omitempty"`
+	SyncedFrom *SyncedFrom `json:"synced_from"`
+	Children   []Block     `json:"children,omitempty"`
+}
+
+type SyncedFrom struct {
+	BlockID BlockID `json:"original_synced_block_id"`
 }
 
 type UnsupportedBlock struct {

--- a/const.go
+++ b/const.go
@@ -174,6 +174,7 @@ const (
 	UserTypeBot    UserType = "bot"
 )
 
+// See https://developers.notion.com/reference/block
 const (
 	BlockTypeParagraph BlockType = "paragraph"
 	BlockTypeHeading1  BlockType = "heading_1"
@@ -199,6 +200,14 @@ const (
 	BlockCallout             BlockType = "callout"
 	BlockQuote               BlockType = "quote"
 	BlockTypeTableOfContents BlockType = "table_of_contents"
+	BlockTypeEquation        BlockType = "equation"
+	BlockTypeBreadcrumb      BlockType = "breadcrumb"
+	BlockTypeColumn          BlockType = "column"
+	BlockTypeColumnList      BlockType = "column_list"
+	BlockTypeLinkPreview     BlockType = "link_preview"
+	BlockTypeLinkToPage      BlockType = "link_to_page"
+	BlockTypeTemplate        BlockType = "template"
+	BlockTypeSyncedBlock     BlockType = "synced_block"
 	BlockTypeUnsupported     BlockType = "unsupported"
 )
 


### PR DESCRIPTION
This is for #45

The following block types were added:
* Breadcrumb
* Column and Column List
* Synced Block
* Link to Page
* Template
* Equation
* Link Preview
Based on https://developers.notion.com/reference/block and testing.