### PR TITLE
Added Property array to support unmarshalling

### DIFF
--- a/page_test.go
+++ b/page_test.go
@@ -43,6 +43,84 @@ func TestPageClient(t *testing.T) {
 					},
 					Archived: false,
 					URL:      "some_url",
+					Properties: notionapi.Properties{
+						"Tags": &notionapi.MultiSelectProperty{
+							ID:   ";s|V",
+							Type: "multi_select",
+							MultiSelect: []notionapi.Option{
+								{
+									ID:    "some_id",
+									Name:  "tag",
+									Color: "blue",
+								},
+							},
+						},
+						"Some another column": &notionapi.PeopleProperty{
+							ID:   "rJt\\",
+							Type: "people",
+							People: []notionapi.User{
+								{
+									Object:    "user",
+									ID:        "some_id",
+									Name:      "some name",
+									AvatarURL: "some.url",
+									Type:      "person",
+									Person: &notionapi.Person{
+										Email: "some@email.com",
+									},
+								},
+							},
+						},
+						"SomeColumn": &notionapi.RichTextProperty{
+							ID:   "~j_@",
+							Type: "rich_text",
+							RichText: []notionapi.RichText{
+								{
+									Type: "text",
+									Text: notionapi.Text{
+										Content: "some text",
+									},
+									Annotations: &notionapi.Annotations{
+										Color: "default",
+									},
+									PlainText: "some text",
+								},
+							},
+						},
+						"Name": &notionapi.TitleProperty{
+							ID:   "title",
+							Type: "title",
+							Title: []notionapi.RichText{
+								{
+									Type: "text",
+									Text: notionapi.Text{
+										Content: "Hello",
+									},
+									Annotations: &notionapi.Annotations{
+										Color: "default",
+									},
+									PlainText: "Hello",
+								},
+							},
+						},
+						"RollupArray": &notionapi.RollupProperty{
+							ID:   "abcd",
+							Type: "rollup",
+							Rollup: notionapi.Rollup{
+								Type: "array",
+								Array: notionapi.PropertyArray{
+									&notionapi.NumberProperty{
+										Type:   "number",
+										Number: 42.2,
+									},
+									&notionapi.NumberProperty{
+										Type:   "number",
+										Number: 56,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			{
@@ -77,8 +155,7 @@ func TestPageClient(t *testing.T) {
 					}
 					return
 				}
-				// TODO: remove properties from comparing for a while. Have to compare with interface somehow
-				got.Properties = nil
+
 				if !reflect.DeepEqual(got, tt.want) {
 					t.Errorf("Get() got = %v, want %v", got, tt.want)
 				}

--- a/testdata/page_get.json
+++ b/testdata/page_get.json
@@ -13,75 +13,81 @@
     "Tags": {
       "id": ";s|V",
       "type": "multi_select",
-      "multi_select": [
-        {
-          "id": "some_id",
-          "name": "tag",
-          "color": "blue"
-        }
-      ]
+      "multi_select": [{
+        "id": "some_id",
+        "name": "tag",
+        "color": "blue"
+      }]
     },
     "Some another column": {
       "id": "rJt\\",
       "type": "people",
-      "people": [
-        {
-          "object": "user",
-          "id": "some_id",
-          "name": "some name",
-          "avatar_url": "some.url",
-          "type": "person",
-          "person": {
-            "email": "some@email.com"
-          }
+      "people": [{
+        "object": "user",
+        "id": "some_id",
+        "name": "some name",
+        "avatar_url": "some.url",
+        "type": "person",
+        "person": {
+          "email": "some@email.com"
         }
-      ]
+      }]
     },
     "SomeColumn": {
       "id": "~j_@",
       "type": "rich_text",
-      "rich_text": [
-        {
-          "type": "text",
-          "text": {
-            "content": "some text",
-            "link": null
-          },
-          "annotations": {
-            "bold": false,
-            "italic": false,
-            "strikethrough": false,
-            "underline": false,
-            "code": false,
-            "color": "default"
-          },
-          "plain_text": "some text",
-          "href": null
-        }
-      ]
+      "rich_text": [{
+        "type": "text",
+        "text": {
+          "content": "some text",
+          "link": null
+        },
+        "annotations": {
+          "bold": false,
+          "italic": false,
+          "strikethrough": false,
+          "underline": false,
+          "code": false,
+          "color": "default"
+        },
+        "plain_text": "some text",
+        "href": null
+      }]
     },
     "Name": {
       "id": "title",
       "type": "title",
-      "title": [
-        {
-          "type": "text",
-          "text": {
-            "content": "Hello",
-            "link": null
-          },
-          "annotations": {
-            "bold": false,
-            "italic": false,
-            "strikethrough": false,
-            "underline": false,
-            "code": false,
-            "color": "default"
-          },
-          "plain_text": "Hello",
-          "href": null
-        }
-      ]
+      "title": [{
+        "type": "text",
+        "text": {
+          "content": "Hello",
+          "link": null
+        },
+        "annotations": {
+          "bold": false,
+          "italic": false,
+          "strikethrough": false,
+          "underline": false,
+          "code": false,
+          "color": "default"
+        },
+        "plain_text": "Hello",
+        "href": null
+      }]
+    },
+    "RollupArray": {
+      "id": "abcd",
+      "type": "rollup",
+      "rollup": {
+        "type": "array",
+        "array": [{
+          "type": "number",
+          "number": 42.2
+        }, {
+          "type": "number",
+          "number": 56
+        }]
+      }
     }
   }
 }


### PR DESCRIPTION
This is response to #51.

This adds the `PropertyArray` type and defines an unmarshalling function
for it. This will allow for the unmarshalling of Rollup arrays.

This also moves some switch logic in `parsePageProperties` to a
`decodeProperty` function which so it can be used in the unmarshalling
of `PropertyArray`.