### PR TITLE
Add parent and url fields to database type

### DIFF
--- a/database.go
+++ b/database.go
@@ -111,6 +111,7 @@ type Database struct {
 	LastEditedTime time.Time  `json:"last_edited_time"`
 	Title          []RichText `json:"title"`
 	Parent         Parent     `json:"parent"`
+	URL            string     `json:"url"`
 	// Properties is a map of property configurations that defines what Page.Properties each page of the database can use
 	Properties PropertyConfigs `json:"properties"`
 }

--- a/database.go
+++ b/database.go
@@ -110,6 +110,7 @@ type Database struct {
 	CreatedTime    time.Time  `json:"created_time"`
 	LastEditedTime time.Time  `json:"last_edited_time"`
 	Title          []RichText `json:"title"`
+	Parent         Parent     `json:"parent"`
 	// Properties is a map of property configurations that defines what Page.Properties each page of the database can use
 	Properties PropertyConfigs `json:"properties"`
 }

--- a/database_test.go
+++ b/database_test.go
@@ -243,6 +243,10 @@ func TestDatabaseClient(t *testing.T) {
 					ID:             "some_id",
 					CreatedTime:    timestamp,
 					LastEditedTime: timestamp,
+					Parent: notionapi.Parent{
+						Type:   "page_id",
+						PageID: "48f8fee9-cd79-4180-bc2f-ec0398253067",
+					},
 					Title: []notionapi.RichText{
 						{
 							Type: notionapi.ObjectTypeText,
@@ -307,6 +311,10 @@ func TestDatabaseClient(t *testing.T) {
 					ID:             "some_id",
 					CreatedTime:    timestamp,
 					LastEditedTime: timestamp,
+					Parent: notionapi.Parent{
+						Type:   "page_id",
+						PageID: "a7744006-9233-4cd0-bf44-3a49de2c01b5",
+					},
 					Title: []notionapi.RichText{
 						{
 							Type:        notionapi.ObjectTypeText,


### PR DESCRIPTION
This adds the parent and url fields to the database struct since the API Reference lists that it has them: https://developers.notion.com/reference/database#all-databases