### PR TITLE
Added Blocks type for Unmarshalling

### DIFF
--- a/block.go
+++ b/block.go
@@ -39,24 +39,16 @@ func (bc *BlockClient) GetChildren(ctx context.Context, id BlockID, pagination *
 		Object     ObjectType `json:"object"`
 		NextCursor string     `json:"next_cursor"`
 		HasMore    bool       `json:"has_more"`
-		Results    []map[string]interface{}
+		Results    Blocks     `json:"results"`
 	}
 	err = json.NewDecoder(res.Body).Decode(&response)
 	if err != nil {
 		return nil, err
 	}
-	results := make([]Block, len(response.Results))
-	for i, r := range response.Results {
-		b, err := decodeBlock(r)
-		if err != nil {
-			return nil, err
-		}
-		results[i] = b
-	}
 
 	return &GetChildrenResponse{
 		Object:     response.Object,
-		Results:    results,
+		Results:    []Block(response.Results),
 		NextCursor: response.NextCursor,
 		HasMore:    response.HasMore,
 	}, nil
@@ -143,6 +135,26 @@ type Block interface {
 	GetType() BlockType
 }
 
+type Blocks []Block
+
+func (b *Blocks) UnmarshalJSON(data []byte) error {
+	var err error
+	mapArr := make([]map[string]interface{}, 0)
+	if err = json.Unmarshal(data, &mapArr); err != nil {
+		return err
+	}
+
+	result := make([]Block, len(mapArr))
+	for i, prop := range mapArr {
+		if result[i], err = decodeBlock(prop); err != nil {
+			return err
+		}
+	}
+
+	*b = result
+	return nil
+}
+
 // BasicBlock defines the common fields of all Notion block types.
 // See https://developers.notion.com/reference/block for the list.
 // BasicBlock implements the Block interface.
@@ -167,7 +179,7 @@ type ParagraphBlock struct {
 
 type Paragraph struct {
 	Text     []RichText `json:"text"`
-	Children []Block    `json:"children,omitempty"`
+	Children Blocks     `json:"children,omitempty"`
 }
 
 type Heading1Block struct {
@@ -197,7 +209,7 @@ type CalloutBlock struct {
 type Callout struct {
 	Text     []RichText `json:"text"`
 	Icon     *Icon      `json:"icon,omitempty"`
-	Children []Block    `json:"children,omitempty"`
+	Children Blocks     `json:"children,omitempty"`
 }
 
 type QuoteBlock struct {
@@ -207,7 +219,7 @@ type QuoteBlock struct {
 
 type Quote struct {
 	Text     []RichText `json:"text"`
-	Children []Block    `json:"children,omitempty"`
+	Children Blocks     `json:"children,omitempty"`
 }
 
 type BulletedListItemBlock struct {
@@ -217,7 +229,7 @@ type BulletedListItemBlock struct {
 
 type ListItem struct {
 	Text     []RichText `json:"text"`
-	Children []Block    `json:"children,omitempty"`
+	Children Blocks     `json:"children,omitempty"`
 }
 
 type NumberedListItemBlock struct {
@@ -232,20 +244,20 @@ type ToDoBlock struct {
 
 type ToDo struct {
 	Text     []RichText `json:"text"`
-	Children []Block    `json:"children,omitempty"`
+	Children Blocks     `json:"children,omitempty"`
 	Checked  bool       `json:"checked,omitempty"`
 }
 
 type ToggleBlock struct {
 	BasicBlock
 	Text     []RichText `json:"text"`
-	Children []Block    `json:"children,omitempty"`
+	Children Blocks     `json:"children,omitempty"`
 	Toggle   Toggle     `json:"toggle"`
 }
 
 type Toggle struct {
 	Text     []RichText `json:"text"`
-	Children []Block    `json:"children,omitempty"`
+	Children Blocks     `json:"children,omitempty"`
 }
 
 type ChildPageBlock struct {
@@ -394,7 +406,7 @@ type ColumnBlock struct {
 
 type Column struct {
 	// Children should at least have 1 block when appending.
-	Children []Block `json:"children"`
+	Children Blocks `json:"children"`
 }
 
 type ColumnListBlock struct {
@@ -405,7 +417,7 @@ type ColumnListBlock struct {
 type ColumnList struct {
 	// Children can only contain column blocks
 	// Children should have at least 2 blocks when appending.
-	Children []Block `json:"children"`
+	Children Blocks `json:"children"`
 }
 
 // NOTE: will only be returned by the API. Cannot be created by the API.
@@ -436,7 +448,7 @@ type TemplateBlock struct {
 
 type Template struct {
 	Text     []RichText `json:"text"`
-	Children []Block    `json:"children,omitempty"`
+	Children Blocks     `json:"children,omitempty"`
 }
 
 type SyncedBlock struct {
@@ -447,7 +459,7 @@ type SyncedBlock struct {
 type Synced struct {
 	// SyncedFrom is nil for the original block.
 	SyncedFrom *SyncedFrom `json:"synced_from"`
-	Children   []Block     `json:"children,omitempty"`
+	Children   Blocks      `json:"children,omitempty"`
 }
 
 type SyncedFrom struct {

--- a/block.go
+++ b/block.go
@@ -35,28 +35,18 @@ func (bc *BlockClient) GetChildren(ctx context.Context, id BlockID, pagination *
 		return nil, err
 	}
 
-	var response struct {
-		Object     ObjectType `json:"object"`
-		NextCursor string     `json:"next_cursor"`
-		HasMore    bool       `json:"has_more"`
-		Results    Blocks     `json:"results"`
-	}
-	err = json.NewDecoder(res.Body).Decode(&response)
+	response := &GetChildrenResponse{}
+	err = json.NewDecoder(res.Body).Decode(response)
 	if err != nil {
 		return nil, err
 	}
 
-	return &GetChildrenResponse{
-		Object:     response.Object,
-		Results:    []Block(response.Results),
-		NextCursor: response.NextCursor,
-		HasMore:    response.HasMore,
-	}, nil
+	return response, nil
 }
 
 type GetChildrenResponse struct {
 	Object     ObjectType `json:"object"`
-	Results    []Block    `json:"results"`
+	Results    Blocks     `json:"results"`
 	NextCursor string     `json:"next_cursor"`
 	HasMore    bool       `json:"has_more"`
 }

--- a/block_test.go
+++ b/block_test.go
@@ -3,6 +3,7 @@ package notionapi_test
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -257,6 +258,180 @@ func TestBlockClient(t *testing.T) {
 					t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
 					return
 				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("Get() got = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	})
+}
+
+func TestBlockArrayUnmarshal(t *testing.T) {
+	timestamp, err := time.Parse(time.RFC3339, "2021-11-04T02:09:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var emoji notionapi.Emoji = "📌"
+	t.Run("BlockArray", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			filePath string
+			want     notionapi.Blocks
+			wantErr  bool
+			err      error
+		}{
+			{
+				name:     "unmarshal",
+				filePath: "testdata/block_array_unmarshal.json",
+				want: notionapi.Blocks{
+					&notionapi.CalloutBlock{
+						BasicBlock: notionapi.BasicBlock{
+							Object:         "block",
+							ID:             "block1",
+							Type:           "callout",
+							CreatedTime:    &timestamp,
+							LastEditedTime: &timestamp,
+						},
+						Callout: notionapi.Callout{
+							Text: []notionapi.RichText{
+								{
+									Type: "text",
+									Text: notionapi.Text{
+										Content: "This page is designed to be shared with students on the web. Click ",
+									},
+									Annotations: &notionapi.Annotations{
+										Color: "default",
+									},
+									PlainText: "This page is designed to be shared with students on the web. Click ",
+								}, {
+									Type: "text",
+									Text: notionapi.Text{
+										Content: "Share",
+									},
+									Annotations: &notionapi.Annotations{
+										Code:  true,
+										Color: "default",
+									},
+									PlainText: "Share",
+								},
+							},
+							Icon: &notionapi.Icon{
+								Type:  "emoji",
+								Emoji: &emoji,
+							},
+						},
+					},
+					&notionapi.Heading1Block{
+						BasicBlock: notionapi.BasicBlock{
+							Object:         "block",
+							ID:             "block2",
+							Type:           "heading_1",
+							CreatedTime:    &timestamp,
+							LastEditedTime: &timestamp,
+						},
+						Heading1: notionapi.Heading{
+							Text: []notionapi.RichText{
+								{
+									Type: "text",
+									Text: notionapi.Text{
+										Content: "History 340",
+									},
+									Annotations: &notionapi.Annotations{
+										Color: "default",
+									},
+									PlainText: "History 340",
+								},
+							},
+						},
+					},
+					&notionapi.ChildDatabaseBlock{
+						BasicBlock: notionapi.BasicBlock{
+							Object:         "block",
+							ID:             "block3",
+							Type:           "child_database",
+							CreatedTime:    &timestamp,
+							LastEditedTime: &timestamp,
+						},
+						ChildDatabase: struct {
+							Title string "json:\"title\""
+						}{
+							Title: "Required Texts",
+						},
+					},
+					&notionapi.ColumnListBlock{
+						BasicBlock: notionapi.BasicBlock{
+							Object:         "block",
+							ID:             "block4",
+							Type:           "column_list",
+							CreatedTime:    &timestamp,
+							LastEditedTime: &timestamp,
+							HasChildren:    true,
+						},
+					},
+					&notionapi.Heading3Block{
+						BasicBlock: notionapi.BasicBlock{
+							Object:         "block",
+							ID:             "block5",
+							Type:           "heading_3",
+							CreatedTime:    &timestamp,
+							LastEditedTime: &timestamp,
+						},
+						Heading3: notionapi.Heading{
+							Text: []notionapi.RichText{
+								{
+									Type: "text",
+									Text: notionapi.Text{
+										Content: "Assignment Submission",
+									},
+									Annotations: &notionapi.Annotations{
+										Bold:  true,
+										Color: "default",
+									},
+									PlainText: "Assignment Submission",
+								},
+							},
+						},
+					},
+					&notionapi.ParagraphBlock{
+						BasicBlock: notionapi.BasicBlock{
+							Object:         "block",
+							ID:             "block6",
+							Type:           "paragraph",
+							CreatedTime:    &timestamp,
+							LastEditedTime: &timestamp,
+						},
+						Paragraph: notionapi.Paragraph{
+							Text: []notionapi.RichText{
+								{
+									Type: "text",
+									Text: notionapi.Text{
+										Content: "All essays and papers are due in lecture (due dates are listed on the schedule). No electronic copies will be accepted!",
+									},
+									Annotations: &notionapi.Annotations{
+										Color: "default",
+									},
+									PlainText: "All essays and papers are due in lecture (due dates are listed on the schedule). No electronic copies will be accepted!",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				data, err := ioutil.ReadFile(tt.filePath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got := make(notionapi.Blocks, 0)
+				err = json.Unmarshal(data, &got)
+				if err != nil {
+					t.Fatal(err)
+				}
+
 				if !reflect.DeepEqual(got, tt.want) {
 					t.Errorf("Get() got = %v, want %v", got, tt.want)
 				}

--- a/testdata/block_array_unmarshal.json
+++ b/testdata/block_array_unmarshal.json
@@ -1,0 +1,128 @@
+[{
+    "object": "block",
+    "id": "block1",
+    "type": "callout",
+    "created_time": "2021-11-04T02:09:00Z",
+    "last_edited_time": "2021-11-04T02:09:00Z",
+    "callout": {
+        "text": [{
+            "type": "text",
+            "text": {
+                "content": "This page is designed to be shared with students on the web. Click "
+            },
+            "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+            },
+            "plain_text": "This page is designed to be shared with students on the web. Click "
+        }, {
+            "type": "text",
+            "text": {
+                "content": "Share"
+            },
+            "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": true,
+                "color": "default"
+            },
+            "plain_text": "Share"
+        }],
+        "icon": {
+            "type": "emoji",
+            "emoji": "📌"
+        }
+    }
+}, {
+    "object": "block",
+    "id": "block2",
+    "type": "heading_1",
+    "created_time": "2021-11-04T02:09:00Z",
+    "last_edited_time": "2021-11-04T02:09:00Z",
+    "heading_1": {
+        "text": [{
+            "type": "text",
+            "text": {
+                "content": "History 340"
+            },
+            "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+            },
+            "plain_text": "History 340"
+        }]
+    }
+}, {
+    "object": "block",
+    "id": "block3",
+    "type": "child_database",
+    "created_time": "2021-11-04T02:09:00Z",
+    "last_edited_time": "2021-11-04T02:09:00Z",
+    "child_database": {
+        "title": "Required Texts"
+    }
+}, {
+    "object": "block",
+    "id": "block4",
+    "type": "column_list",
+    "created_time": "2021-11-04T02:09:00Z",
+    "last_edited_time": "2021-11-04T02:09:00Z",
+    "has_children": true,
+    "column_list": {}
+}, {
+    "object": "block",
+    "id": "block5",
+    "type": "heading_3",
+    "created_time": "2021-11-04T02:09:00Z",
+    "last_edited_time": "2021-11-04T02:09:00Z",
+    "heading_3": {
+        "text": [{
+            "type": "text",
+            "text": {
+                "content": "Assignment Submission"
+            },
+            "annotations": {
+                "bold": true,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+            },
+            "plain_text": "Assignment Submission"
+        }]
+    }
+}, {
+    "object": "block",
+    "id": "block6",
+    "type": "paragraph",
+    "created_time": "2021-11-04T02:09:00Z",
+    "last_edited_time": "2021-11-04T02:09:00Z",
+    "paragraph": {
+        "text": [{
+            "type": "text",
+            "text": {
+                "content": "All essays and papers are due in lecture (due dates are listed on the schedule). No electronic copies will be accepted!"
+            },
+            "annotations": {
+                "bold": false,
+                "italic": false,
+                "strikethrough": false,
+                "underline": false,
+                "code": false,
+                "color": "default"
+            },
+            "plain_text": "All essays and papers are due in lecture (due dates are listed on the schedule). No electronic copies will be accepted!"
+        }]
+    }
+}]


### PR DESCRIPTION
Currently there is a problem with unmarshalling into a Block interface, since the decodeBlock function is unexported. This is an issue when trying to use the Block type outside of the API, such as loading a Block from a JSON file. A Block itself cannot be defined to unmarshal into, as it is an interface and can't be a receiver, but a []Block can be, as done here.

[]Block cannot be unmarshalled into as it is an interface. This defines a Blocks type, which is just a []Block, and an UnmarshallJSON method so that a JSON string/byte slice can unmarshall into a []Block.