### PR TITLE
Add Children to Heading Blocks

### DIFF
--- a/block.go
+++ b/block.go
@@ -208,7 +208,8 @@ type Heading1Block struct {
 }
 
 type Heading struct {
-	Text []RichText `json:"text"`
+	Text     []RichText `json:"text"`
+	Children Blocks     `json:"children,omitempty"`
 }
 
 type Heading2Block struct {

--- a/block_test.go
+++ b/block_test.go
@@ -78,13 +78,15 @@ func TestBlockClient(t *testing.T) {
 								Type:   notionapi.BlockTypeHeading2,
 							},
 							Heading2: struct {
-								Text []notionapi.RichText `json:"text"`
+								Text     []notionapi.RichText `json:"text"`
+								Children notionapi.Blocks     `json:"children,omitempty"`
 							}{[]notionapi.RichText{
 								{
 									Type: notionapi.ObjectTypeText,
 									Text: notionapi.Text{Content: "Hello"},
 								},
-							}},
+							}, nil,
+							},
 						},
 					},
 				},

--- a/page_test.go
+++ b/page_test.go
@@ -402,7 +402,8 @@ func TestPageCreateRequest_MarshallJSON(t *testing.T) {
 							Type:   notionapi.BlockTypeHeading2,
 						},
 						Heading2: struct {
-							Text []notionapi.RichText `json:"text"`
+							Text     []notionapi.RichText `json:"text"`
+							Children notionapi.Blocks     `json:"children,omitempty"`
 						}{
 							Text: []notionapi.RichText{
 								{


### PR DESCRIPTION
Toggle Headings were recently added. With them, the heading blocks now
also can have children. This adds a children field to the heading block.

Requesting a toggle heading has the `has_children` set to true.