### PR TITLE
Added `omitempty` to filter.go

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -32,12 +32,12 @@ type TextFilterCondition struct {
 }
 
 type NumberFilterCondition struct {
-	Equals               float64 `json:"equals,omitempty"`
-	DoesNotEqual         float64 `json:"does_not_equal,omitempty"`
-	GreaterThan          float64 `json:"greater_than,omitempty"`
-	LessThan             float64 `json:"less_than,omitempty"`
-	GreaterThanOrEqualTo float64 `json:"greater_than_or_equal_to,omitempty"`
-	LessThanOrEqualTo    float64 `json:"less_than_or_equal_to,omitempty"`
+	Equals               *float64 `json:"equals,omitempty"`
+	DoesNotEqual         *float64 `json:"does_not_equal,omitempty"`
+	GreaterThan          *float64 `json:"greater_than,omitempty"`
+	LessThan             *float64 `json:"less_than,omitempty"`
+	GreaterThanOrEqualTo *float64 `json:"greater_than_or_equal_to,omitempty"`
+	LessThanOrEqualTo    *float64 `json:"less_than_or_equal_to,omitempty"`
 	IsEmpty              bool    `json:"is_empty,omitempty"`
 	IsNotEmpty           bool    `json:"is_not_empty,omitempty"`
 }

--- a/filter.go
+++ b/filter.go
@@ -36,8 +36,8 @@ type NumberFilterCondition struct {
 	DoesNotEqual         float64 `json:"does_not_equal,omitempty"`
 	GreaterThan          float64 `json:"greater_than,omitempty"`
 	LessThan             float64 `json:"less_than,omitempty"`
-	GreaterThanOrEqualTo float64 `json:"greater_than_or_equal_to"`
-	LessThanOrEqualTo    float64 `json:"less_than_or_equal_to"`
+	GreaterThanOrEqualTo float64 `json:"greater_than_or_equal_to,omitempty"`
+	LessThanOrEqualTo    float64 `json:"less_than_or_equal_to,omitempty"`
 	IsEmpty              bool    `json:"is_empty,omitempty"`
 	IsNotEmpty           bool    `json:"is_not_empty,omitempty"`
 }


### PR DESCRIPTION
Without `omitempty`, json marshaling will include `greater_than_or_equal_to: 0` and `less_than_or_equal_to: 0` which result in wrong request body.

```go
	db, err := r.client.Database.Query(ctx, notionapi.DatabaseID(config.C.Notion.DatabaseIDs.Finance), &notionapi.DatabaseQueryRequest{
		PropertyFilter: &notionapi.PropertyFilter{
			Property: string(notion.FinancePropertyAmount),
			Number: &notionapi.NumberFilterCondition{
				LessThanOrEqualTo: 2,
			},
		},
	})
```

before adding `omitempty`
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/59773847/159196355-7868af95-f2e5-4a52-bfdc-866a86b62e50.png">

after adding `omitempty`
<img width="1147" alt="image" src="https://user-images.githubusercontent.com/59773847/159196417-7a373546-0e28-478f-8946-969c9c92252f.png">
