### PR TITLE
Update Default version to latest

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 const (
 	apiURL        = "https://api.notion.com"
 	apiVersion    = "v1"
-	notionVersion = "2021-08-16"
+	notionVersion = "2022-02-22"
 )
 
 type Token string


### PR DESCRIPTION
This updates the default version that the client uses to the February version of the API instead of August as noted in the changelog: https://developers.notion.com/changelog.