### PR TITLE
Enable to attach an icon when creating a page

### DIFF
--- a/page.go
+++ b/page.go
@@ -90,6 +90,7 @@ type PageCreateRequest struct {
 	Parent     Parent     `json:"parent"`
 	Properties Properties `json:"properties"`
 	Children   []Block    `json:"children,omitempty"`
+	Icon       *Icon      `json:"icon,omitempty"`
 }
 
 func handlePageResponse(res *http.Response) (*Page, error) {


### PR DESCRIPTION
According to this [link](https://developers.notion.com/reference/post-page), I would like to attach an icon when creating a new page.