### PR TITLE
Adds CreatedBy and LastEditedBy Fields to Structs

### DIFF
--- a/block.go
+++ b/block.go
@@ -160,6 +160,8 @@ type BasicBlock struct {
 	Type           BlockType  `json:"type"`
 	CreatedTime    *time.Time `json:"created_time,omitempty"`
 	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	CreatedBy      User       `json:"created_by"`
+	LastEditedBy   User       `json:"last_edited_by"`
 	HasChildren    bool       `json:"has_children,omitempty"`
 	Archived       bool       `json:"archived,omitempty"`
 }

--- a/block.go
+++ b/block.go
@@ -160,8 +160,8 @@ type BasicBlock struct {
 	Type           BlockType  `json:"type"`
 	CreatedTime    *time.Time `json:"created_time,omitempty"`
 	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
-	CreatedBy      User       `json:"created_by"`
-	LastEditedBy   User       `json:"last_edited_by"`
+	CreatedBy      *User      `json:"created_by,omitempty"`
+	LastEditedBy   *User      `json:"last_edited_by,omitempty"`
 	HasChildren    bool       `json:"has_children,omitempty"`
 	Archived       bool       `json:"archived,omitempty"`
 }

--- a/block_test.go
+++ b/block_test.go
@@ -100,6 +100,14 @@ func TestBlockClient(t *testing.T) {
 								CreatedTime:    &timestamp,
 								LastEditedTime: &timestamp,
 								Type:           notionapi.BlockTypeParagraph,
+								CreatedBy: notionapi.User{
+									Object: "user",
+									ID:     "some_id",
+								},
+								LastEditedBy: notionapi.User{
+									Object: "user",
+									ID:     "some_id",
+								},
 							},
 							Paragraph: notionapi.Paragraph{
 								Text: []notionapi.RichText{
@@ -126,22 +134,22 @@ func TestBlockClient(t *testing.T) {
 				client := notionapi.NewClient("some_token", notionapi.WithHTTPClient(c))
 				got, err := client.Block.AppendChildren(context.Background(), tt.id, tt.request)
 				if (err != nil) != tt.wantErr {
-					t.Errorf("AppendChidlren() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("AppendChildren() error = %v, wantErr %v", err, tt.wantErr)
 					return
 				}
 				a, err := json.Marshal(got)
 				if err != nil {
-					t.Errorf("AppendChidlren() marhall error = %v", err)
+					t.Errorf("AppendChildren() marhall error = %v", err)
 					return
 				}
 				b, err := json.Marshal(tt.want)
 				if err != nil {
-					t.Errorf("AppendChidlren() marhall error = %v", err)
+					t.Errorf("AppendChildren() marshal error = %v", err)
 					return
 				}
 
 				if !(string(a) == string(b)) {
-					t.Errorf("AppendChidlren() got = %v, want %v", got, tt.want)
+					t.Errorf("AppendChildren() got = %v, want %v", got, tt.want)
 				}
 			})
 		}
@@ -169,7 +177,15 @@ func TestBlockClient(t *testing.T) {
 						Type:           notionapi.BlockTypeChildPage,
 						CreatedTime:    &timestamp,
 						LastEditedTime: &timestamp,
-						HasChildren:    true,
+						CreatedBy: notionapi.User{
+							Object: "user",
+							ID:     "some_id",
+						},
+						LastEditedBy: notionapi.User{
+							Object: "user",
+							ID:     "some_id",
+						},
+						HasChildren: true,
 					},
 					ChildPage: struct {
 						Title string `json:"title"`
@@ -275,6 +291,10 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 	}
 
 	var emoji notionapi.Emoji = "📌"
+	var user notionapi.User = notionapi.User{
+		Object: "user",
+		ID:     "some_id",
+	}
 	t.Run("BlockArray", func(t *testing.T) {
 		tests := []struct {
 			name     string
@@ -294,6 +314,8 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							Type:           "callout",
 							CreatedTime:    &timestamp,
 							LastEditedTime: &timestamp,
+							CreatedBy:      user,
+							LastEditedBy:   user,
 						},
 						Callout: notionapi.Callout{
 							Text: []notionapi.RichText{
@@ -331,6 +353,8 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							Type:           "heading_1",
 							CreatedTime:    &timestamp,
 							LastEditedTime: &timestamp,
+							CreatedBy:      user,
+							LastEditedBy:   user,
 						},
 						Heading1: notionapi.Heading{
 							Text: []notionapi.RichText{
@@ -354,6 +378,8 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							Type:           "child_database",
 							CreatedTime:    &timestamp,
 							LastEditedTime: &timestamp,
+							CreatedBy:      user,
+							LastEditedBy:   user,
 						},
 						ChildDatabase: struct {
 							Title string "json:\"title\""
@@ -368,6 +394,8 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							Type:           "column_list",
 							CreatedTime:    &timestamp,
 							LastEditedTime: &timestamp,
+							CreatedBy:      user,
+							LastEditedBy:   user,
 							HasChildren:    true,
 						},
 					},
@@ -378,6 +406,8 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							Type:           "heading_3",
 							CreatedTime:    &timestamp,
 							LastEditedTime: &timestamp,
+							CreatedBy:      user,
+							LastEditedBy:   user,
 						},
 						Heading3: notionapi.Heading{
 							Text: []notionapi.RichText{
@@ -402,6 +432,8 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							Type:           "paragraph",
 							CreatedTime:    &timestamp,
 							LastEditedTime: &timestamp,
+							CreatedBy:      user,
+							LastEditedBy:   user,
 						},
 						Paragraph: notionapi.Paragraph{
 							Text: []notionapi.RichText{

--- a/block_test.go
+++ b/block_test.go
@@ -100,11 +100,11 @@ func TestBlockClient(t *testing.T) {
 								CreatedTime:    &timestamp,
 								LastEditedTime: &timestamp,
 								Type:           notionapi.BlockTypeParagraph,
-								CreatedBy: notionapi.User{
+								CreatedBy: &notionapi.User{
 									Object: "user",
 									ID:     "some_id",
 								},
-								LastEditedBy: notionapi.User{
+								LastEditedBy: &notionapi.User{
 									Object: "user",
 									ID:     "some_id",
 								},
@@ -177,11 +177,11 @@ func TestBlockClient(t *testing.T) {
 						Type:           notionapi.BlockTypeChildPage,
 						CreatedTime:    &timestamp,
 						LastEditedTime: &timestamp,
-						CreatedBy: notionapi.User{
+						CreatedBy: &notionapi.User{
 							Object: "user",
 							ID:     "some_id",
 						},
-						LastEditedBy: notionapi.User{
+						LastEditedBy: &notionapi.User{
 							Object: "user",
 							ID:     "some_id",
 						},
@@ -291,7 +291,7 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 	}
 
 	var emoji notionapi.Emoji = "📌"
-	var user notionapi.User = notionapi.User{
+	var user *notionapi.User = &notionapi.User{
 		Object: "user",
 		ID:     "some_id",
 	}

--- a/database.go
+++ b/database.go
@@ -109,6 +109,8 @@ type Database struct {
 	ID             ObjectID   `json:"id"`
 	CreatedTime    time.Time  `json:"created_time"`
 	LastEditedTime time.Time  `json:"last_edited_time"`
+	CreatedBy      User       `json:"created_by,omitempty"`
+	LastEditedBy   User       `json:"last_edited_by,omitempty"`
 	Title          []RichText `json:"title"`
 	Parent         Parent     `json:"parent"`
 	URL            string     `json:"url"`

--- a/database_test.go
+++ b/database_test.go
@@ -16,6 +16,11 @@ func TestDatabaseClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var user = notionapi.User{
+		Object: "user",
+		ID:     "some_id",
+	}
+
 	t.Run("Get", func(t *testing.T) {
 		tests := []struct {
 			name       string
@@ -36,6 +41,8 @@ func TestDatabaseClient(t *testing.T) {
 					ID:             "some_id",
 					CreatedTime:    timestamp,
 					LastEditedTime: timestamp,
+					CreatedBy:      user,
+					LastEditedBy:   user,
 					Title: []notionapi.RichText{
 						{
 							Type:        notionapi.ObjectTypeText,
@@ -106,6 +113,8 @@ func TestDatabaseClient(t *testing.T) {
 							ID:             "some_id",
 							CreatedTime:    timestamp,
 							LastEditedTime: timestamp,
+							CreatedBy:      user,
+							LastEditedBy:   user,
 							Title: []notionapi.RichText{
 								{
 									Type: notionapi.ObjectTypeText,
@@ -177,6 +186,8 @@ func TestDatabaseClient(t *testing.T) {
 							ID:             "some_id",
 							CreatedTime:    timestamp,
 							LastEditedTime: timestamp,
+							CreatedBy:      user,
+							LastEditedBy:   user,
 							Parent: notionapi.Parent{
 								Type:       notionapi.ParentTypeDatabaseID,
 								DatabaseID: "some_id",
@@ -243,6 +254,8 @@ func TestDatabaseClient(t *testing.T) {
 					ID:             "some_id",
 					CreatedTime:    timestamp,
 					LastEditedTime: timestamp,
+					CreatedBy:      user,
+					LastEditedBy:   user,
 					Parent: notionapi.Parent{
 						Type:   "page_id",
 						PageID: "48f8fee9-cd79-4180-bc2f-ec0398253067",
@@ -311,6 +324,8 @@ func TestDatabaseClient(t *testing.T) {
 					ID:             "some_id",
 					CreatedTime:    timestamp,
 					LastEditedTime: timestamp,
+					CreatedBy:      user,
+					LastEditedBy:   user,
 					Parent: notionapi.Parent{
 						Type:   "page_id",
 						PageID: "a7744006-9233-4cd0-bf44-3a49de2c01b5",

--- a/page.go
+++ b/page.go
@@ -66,6 +66,8 @@ type Page struct {
 	ID             ObjectID   `json:"id"`
 	CreatedTime    time.Time  `json:"created_time"`
 	LastEditedTime time.Time  `json:"last_edited_time"`
+	CreatedBy      User       `json:"created_by,omitempty"`
+	LastEditedBy   User       `json:"last_edited_by,omitempty"`
 	Archived       bool       `json:"archived"`
 	Properties     Properties `json:"properties"`
 	Parent         Parent     `json:"parent"`

--- a/page_test.go
+++ b/page_test.go
@@ -37,6 +37,14 @@ func TestPageClient(t *testing.T) {
 					ID:             "some_id",
 					CreatedTime:    timestamp,
 					LastEditedTime: timestamp,
+					CreatedBy: notionapi.User{
+						Object: "user",
+						ID:     "some_id",
+					},
+					LastEditedBy: notionapi.User{
+						Object: "user",
+						ID:     "some_id",
+					},
 					Parent: notionapi.Parent{
 						Type:       notionapi.ParentTypeDatabaseID,
 						DatabaseID: "some_id",
@@ -196,6 +204,14 @@ func TestPageClient(t *testing.T) {
 					ID:             "some_id",
 					CreatedTime:    timestamp,
 					LastEditedTime: timestamp,
+					CreatedBy: notionapi.User{
+						Object: "user",
+						ID:     "some_id",
+					},
+					LastEditedBy: notionapi.User{
+						Object: "user",
+						ID:     "some_id",
+					},
 					Parent: notionapi.Parent{
 						Type:       notionapi.ParentTypeDatabaseID,
 						DatabaseID: "some_id",
@@ -258,6 +274,14 @@ func TestPageClient(t *testing.T) {
 					ID:             "some_id",
 					CreatedTime:    timestamp,
 					LastEditedTime: timestamp,
+					CreatedBy: notionapi.User{
+						Object: "user",
+						ID:     "some_id",
+					},
+					LastEditedBy: notionapi.User{
+						Object: "user",
+						ID:     "some_id",
+					},
 					Parent: notionapi.Parent{
 						Type:       notionapi.ParentTypeDatabaseID,
 						DatabaseID: "some_id",

--- a/testdata/block_append_children.json
+++ b/testdata/block_append_children.json
@@ -6,6 +6,14 @@
       "id": "some_id",
       "created_time": "2021-05-24T05:06:34.827Z",
       "last_edited_time": "2021-05-24T05:06:34.827Z",
+      "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
       "has_children": false,
       "archived": false,
       "type": "paragraph",

--- a/testdata/block_array_unmarshal.json
+++ b/testdata/block_array_unmarshal.json
@@ -4,6 +4,14 @@
     "type": "callout",
     "created_time": "2021-11-04T02:09:00Z",
     "last_edited_time": "2021-11-04T02:09:00Z",
+    "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
     "callout": {
         "text": [{
             "type": "text",
@@ -45,6 +53,14 @@
     "type": "heading_1",
     "created_time": "2021-11-04T02:09:00Z",
     "last_edited_time": "2021-11-04T02:09:00Z",
+    "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
     "heading_1": {
         "text": [{
             "type": "text",
@@ -68,6 +84,14 @@
     "type": "child_database",
     "created_time": "2021-11-04T02:09:00Z",
     "last_edited_time": "2021-11-04T02:09:00Z",
+    "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
     "child_database": {
         "title": "Required Texts"
     }
@@ -77,6 +101,14 @@
     "type": "column_list",
     "created_time": "2021-11-04T02:09:00Z",
     "last_edited_time": "2021-11-04T02:09:00Z",
+    "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
     "has_children": true,
     "column_list": {}
 }, {
@@ -85,6 +117,14 @@
     "type": "heading_3",
     "created_time": "2021-11-04T02:09:00Z",
     "last_edited_time": "2021-11-04T02:09:00Z",
+    "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
     "heading_3": {
         "text": [{
             "type": "text",
@@ -108,6 +148,14 @@
     "type": "paragraph",
     "created_time": "2021-11-04T02:09:00Z",
     "last_edited_time": "2021-11-04T02:09:00Z",
+    "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
     "paragraph": {
         "text": [{
             "type": "text",

--- a/testdata/block_get.json
+++ b/testdata/block_get.json
@@ -3,6 +3,14 @@
   "id": "some_id",
   "created_time": "2021-05-24T05:06:34.827Z",
   "last_edited_time": "2021-05-24T05:06:34.827Z",
+  "created_by":{
+    "object": "user",
+    "id": "some_id"
+  },
+  "last_edited_by":{
+    "object": "user",
+    "id": "some_id"
+  },
   "has_children": true,
   "archived": false,
   "type": "child_page",

--- a/testdata/block_get_children.json
+++ b/testdata/block_get_children.json
@@ -6,6 +6,14 @@
       "id": "some_id",
       "created_time": "2021-05-30T09:46:51.232Z",
       "last_edited_time": "2021-05-30T09:46:00.000Z",
+      "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id2"
+      },
       "has_children": false,
       "type": "heading_1",
       "heading_1": {
@@ -35,6 +43,14 @@
       "id": "some_id",
       "created_time": "2021-05-30T09:47:03.727Z",
       "last_edited_time": "2021-05-30T09:47:00.000Z",
+      "created_by":{
+        "object": "user",
+        "id": "some_id2"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
       "has_children": false,
       "type": "to_do",
       "to_do": {

--- a/testdata/database_create.json
+++ b/testdata/database_create.json
@@ -13,6 +13,14 @@
   },
   "created_time": "2021-05-24T05:06:34.827Z",
   "last_edited_time": "2021-05-24T05:06:34.827Z",
+  "created_by":{
+    "object": "user",
+    "id": "some_id"
+  },
+  "last_edited_by":{
+    "object": "user",
+    "id": "some_id"
+  },
   "title": [
     {
       "type": "text",

--- a/testdata/database_get.json
+++ b/testdata/database_get.json
@@ -3,6 +3,14 @@
   "id": "some_id",
   "created_time": "2021-05-24T05:06:34.827Z",
   "last_edited_time": "2021-05-24T05:06:34.827Z",
+  "created_by":{
+    "object": "user",
+    "id": "some_id"
+  },
+  "last_edited_by":{
+    "object": "user",
+    "id": "some_id"
+  },
   "title": [
     {
       "type": "text",

--- a/testdata/database_list.json
+++ b/testdata/database_list.json
@@ -6,6 +6,14 @@
       "id": "some_id",
       "created_time": "2021-05-24T05:06:34.827Z",
       "last_edited_time": "2021-05-24T05:06:34.827Z",
+      "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
       "title": [
         {
           "type": "text",

--- a/testdata/database_query.json
+++ b/testdata/database_query.json
@@ -6,6 +6,14 @@
       "id": "some_id",
       "created_time": "2021-05-24T05:06:34.827Z",
       "last_edited_time": "2021-05-24T05:06:34.827Z",
+      "created_by":{
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by":{
+        "object": "user",
+        "id": "some_id"
+      },
       "parent": {
         "type": "database_id",
         "database_id": "some_id"

--- a/testdata/database_update.json
+++ b/testdata/database_update.json
@@ -3,6 +3,14 @@
   "id": "some_id",
   "created_time": "2021-05-24T05:06:34.827Z",
   "last_edited_time": "2021-05-24T05:06:34.827Z",
+  "created_by":{
+    "object": "user",
+    "id": "some_id"
+  },
+  "last_edited_by":{
+    "object": "user",
+    "id": "some_id"
+  },
   "parent": {
     "type": "page_id",
     "page_id": "48f8fee9-cd79-4180-bc2f-ec0398253067"

--- a/testdata/page_create.json
+++ b/testdata/page_create.json
@@ -3,6 +3,14 @@
   "id": "some_id",
   "created_time": "2021-05-24T05:06:34.827Z",
   "last_edited_time": "2021-05-24T05:06:34.827Z",
+  "created_by": {
+    "object": "user",
+    "id": "some_id"
+  },
+  "last_edited_by": {
+    "object": "user",
+    "id": "some_id"
+  },
   "parent": {
     "type": "database_id",
     "database_id": "some_id"

--- a/testdata/page_get.json
+++ b/testdata/page_get.json
@@ -3,6 +3,14 @@
   "id": "some_id",
   "created_time": "2021-05-24T05:06:34.827Z",
   "last_edited_time": "2021-05-24T05:06:34.827Z",
+  "created_by": {
+    "object": "user",
+    "id": "some_id"
+  },
+  "last_edited_by": {
+    "object": "user",
+    "id": "some_id"
+  },
   "parent": {
     "type": "database_id",
     "database_id": "some_id"

--- a/testdata/page_update.json
+++ b/testdata/page_update.json
@@ -3,6 +3,14 @@
   "id": "some_id",
   "created_time": "2021-05-24T05:06:34.827Z",
   "last_edited_time": "2021-05-24T05:06:34.827Z",
+  "created_by": {
+    "object": "user",
+    "id": "some_id"
+  },
+  "last_edited_by": {
+    "object": "user",
+    "id": "some_id"
+  },
   "parent": {
     "type": "database_id",
     "database_id": "some_id"

--- a/testdata/search.json
+++ b/testdata/search.json
@@ -6,6 +6,14 @@
       "id": "some_id",
       "created_time": "2021-05-29T08:51:07.831Z",
       "last_edited_time": "2021-05-29T08:51:07.831Z",
+      "created_by": {
+        "object": "user",
+        "id": "some_id"
+      },
+      "last_edited_by": {
+        "object": "user",
+        "id": "some_id"
+      },
       "parent": {
         "type": "database_id",
         "database_id": "some_id"


### PR DESCRIPTION
The Notion API changelog notes that now the 3 main objects, Blocks, Pages and Databases all contain `CreatedBy` and `LastEditedBy` properties.
This PR adds these fields to the structs and updates the tests.