### PR TITLE
Add methods to Block to retrieve CreatedBy and LastEditedBy

### DIFF
--- a/block.go
+++ b/block.go
@@ -158,6 +158,8 @@ type Block interface {
 	GetObject() ObjectType
 	GetCreatedTime() *time.Time
 	GetLastEditedTime() *time.Time
+	GetCreatedBy() *User
+	GetLastEditedBy() *User
 	GetHasChildren() bool
 	GetArchived() bool
 }
@@ -215,6 +217,14 @@ func (b BasicBlock) GetCreatedTime() *time.Time {
 
 func (b BasicBlock) GetLastEditedTime() *time.Time {
 	return b.LastEditedTime
+}
+
+func (b BasicBlock) GetCreatedBy() *User {
+	return b.CreatedBy
+}
+
+func (b BasicBlock) GetLastEditedBy() *User {
+	return b.LastEditedBy
 }
 
 func (b BasicBlock) GetHasChildren() bool {

--- a/block.go
+++ b/block.go
@@ -235,6 +235,8 @@ func (b BasicBlock) GetArchived() bool {
 	return b.Archived
 }
 
+var _ Block = (*BasicBlock)(nil)
+
 type ParagraphBlock struct {
 	BasicBlock
 	Paragraph Paragraph `json:"paragraph"`


### PR DESCRIPTION
This adds getters for the CreatedBy and LastEditedBy fields of the Block
interface and the BasicBlock struct.

Missed this during the previous PR.