### PR TITLE
update text property to 2022-02-22 backwards incompatible changes

### DIFF
--- a/block.go
+++ b/block.go
@@ -243,7 +243,7 @@ type Heading1Block struct {
 }
 
 type Heading struct {
-	Text     []RichText `json:"text"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 }
 
@@ -263,7 +263,9 @@ type CalloutBlock struct {
 }
 
 type Callout struct {
-	Text     []RichText `json:"text"`
+	// DEPRECATED use RichText instead
+	Text     []RichText `json:"text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Icon     *Icon      `json:"icon,omitempty"`
 	Children Blocks     `json:"children,omitempty"`
 }
@@ -274,7 +276,9 @@ type QuoteBlock struct {
 }
 
 type Quote struct {
-	Text     []RichText `json:"text"`
+	// DEPRECATED use RichText instead
+	Text     []RichText `json:"text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 }
 
@@ -305,7 +309,9 @@ type BulletedListItemBlock struct {
 }
 
 type ListItem struct {
-	Text     []RichText `json:"text"`
+	// DEPRECATED use RichText instead
+	Text     []RichText `json:"text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 }
 
@@ -320,20 +326,26 @@ type ToDoBlock struct {
 }
 
 type ToDo struct {
-	Text     []RichText `json:"text"`
+	// DEPRECATED use RichText instead
+	Text     []RichText `json:"text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 	Checked  bool       `json:"checked,omitempty"`
 }
 
 type ToggleBlock struct {
 	BasicBlock
-	Text     []RichText `json:"text"`
+	// DEPRECATED use RichText instead
+	Text     []RichText `json:"text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 	Toggle   Toggle     `json:"toggle"`
 }
 
 type Toggle struct {
-	Text     []RichText `json:"text"`
+	// DEPRECATED use RichText instead
+	Text     []RichText `json:"text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 }
 
@@ -383,7 +395,9 @@ type CodeBlock struct {
 }
 
 type Code struct {
-	Text     []RichText `json:"text"`
+	// DEPRECATED use RichText instead
+	Text     []RichText `json:"text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Language string     `json:"language"`
 }
 
@@ -524,7 +538,9 @@ type TemplateBlock struct {
 }
 
 type Template struct {
-	Text     []RichText `json:"text"`
+	// DEPRECATED use RichText instead
+	Text     []RichText `json:"text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 }
 

--- a/block_test.go
+++ b/block_test.go
@@ -78,7 +78,7 @@ func TestBlockClient(t *testing.T) {
 								Type:   notionapi.BlockTypeHeading2,
 							},
 							Heading2: struct {
-								Text     []notionapi.RichText `json:"text"`
+								RichText []notionapi.RichText `json:"rich_text"`
 								Children notionapi.Blocks     `json:"children,omitempty"`
 							}{[]notionapi.RichText{
 								{
@@ -318,7 +318,7 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							LastEditedBy:   user,
 						},
 						Callout: notionapi.Callout{
-							Text: []notionapi.RichText{
+							RichText: []notionapi.RichText{
 								{
 									Type: "text",
 									Text: notionapi.Text{
@@ -357,7 +357,7 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							LastEditedBy:   user,
 						},
 						Heading1: notionapi.Heading{
-							Text: []notionapi.RichText{
+							RichText: []notionapi.RichText{
 								{
 									Type: "text",
 									Text: notionapi.Text{
@@ -410,7 +410,7 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 							LastEditedBy:   user,
 						},
 						Heading3: notionapi.Heading{
-							Text: []notionapi.RichText{
+							RichText: []notionapi.RichText{
 								{
 									Type: "text",
 									Text: notionapi.Text{

--- a/page_test.go
+++ b/page_test.go
@@ -426,10 +426,10 @@ func TestPageCreateRequest_MarshallJSON(t *testing.T) {
 							Type:   notionapi.BlockTypeHeading2,
 						},
 						Heading2: struct {
-							Text     []notionapi.RichText `json:"text"`
+							RichText []notionapi.RichText `json:"rich_text"`
 							Children notionapi.Blocks     `json:"children,omitempty"`
 						}{
-							Text: []notionapi.RichText{
+							RichText: []notionapi.RichText{
 								{
 									Type: notionapi.ObjectTypeText,
 									Text: notionapi.Text{Content: "Lacinato"},
@@ -458,7 +458,7 @@ func TestPageCreateRequest_MarshallJSON(t *testing.T) {
 					},
 				},
 			},
-			want: []byte(`{"parent":{"database_id":"some_id"},"properties":{"Link":{"url":"some_url"},"Name":{"title":[{"text":{"content":"New Media Article"}}]},"Publishing/Release Date":{"date":{"start":"2020-12-08T12:00:00Z","end":null}},"Read":{"checkbox":false},"Summary":{"text":[{"type":"text","text":{"content":"Some content"},"annotations":{"bold":true,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"blue"},"plain_text":"Some content"}]},"Type":{"select":{"id":"some_id","name":"Article","color":"default"}}},"children":[{"object":"block","type":"heading_2","heading_2":{"text":[{"type":"text","text":{"content":"Lacinato"}}]}},{"object":"block","type":"paragraph","paragraph":{"rich_text":[{"text":{"content":"Lacinato","link":{"url":"some_url"}}}]}}]}`),
+			want: []byte(`{"parent":{"database_id":"some_id"},"properties":{"Link":{"url":"some_url"},"Name":{"title":[{"text":{"content":"New Media Article"}}]},"Publishing/Release Date":{"date":{"start":"2020-12-08T12:00:00Z","end":null}},"Read":{"checkbox":false},"Summary":{"text":[{"type":"text","text":{"content":"Some content"},"annotations":{"bold":true,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"blue"},"plain_text":"Some content"}]},"Type":{"select":{"id":"some_id","name":"Article","color":"default"}}},"children":[{"object":"block","type":"heading_2","heading_2":{"rich_text":[{"type":"text","text":{"content":"Lacinato"}}]}},{"object":"block","type":"paragraph","paragraph":{"rich_text":[{"text":{"content":"Lacinato","link":{"url":"some_url"}}}]}}]}`),
 		},
 	}
 

--- a/testdata/block_array_unmarshal.json
+++ b/testdata/block_array_unmarshal.json
@@ -13,7 +13,7 @@
         "id": "some_id"
       },
     "callout": {
-        "text": [{
+        "rich_text": [{
             "type": "text",
             "text": {
                 "content": "This page is designed to be shared with students on the web. Click "
@@ -62,7 +62,7 @@
         "id": "some_id"
       },
     "heading_1": {
-        "text": [{
+        "rich_text": [{
             "type": "text",
             "text": {
                 "content": "History 340"
@@ -126,7 +126,7 @@
         "id": "some_id"
       },
     "heading_3": {
-        "text": [{
+        "rich_text": [{
             "type": "text",
             "text": {
                 "content": "Assignment Submission"


### PR DESCRIPTION
similar to #69 but does the other block types in addition to just `paragraph`

from https://developers.notion.com/changelog/releasing-notion-version-2022-02-22
```
To be consistent with the database property type, we have renamed the text property to rich_text. This affects the following block types: paragraph, heading_1, heading_2, heading_3, callout, quote, bulleted_list_item, numbered_list_item, to_do ,toggle, code ,template.
```

I think there might be some other changes in the linked page too that need adjustments, but this should fix some blocks.