### PR TITLE
Support title and richtext filters

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -440,6 +440,30 @@ func TestDatabaseQueryRequest_MarshalJSON(t *testing.T) {
 			},
 			want: []byte(`{"filter":{"property":"created_at","date":{"equals":"2021-05-10T02:43:42Z","past_week":{}}}}`),
 		},
+		{
+			name: "title filter",
+			req: &notionapi.DatabaseQueryRequest{
+				PropertyFilter: &notionapi.PropertyFilter{
+					Property: "Name",
+					Title: &notionapi.TextFilterCondition{
+						Equals: "title",
+					},
+				},
+			},
+			want: []byte(`{"filter":{"property":"Name","title":{"equals":"title"}}}`),
+		},
+		{
+			name: "richtext filter",
+			req: &notionapi.DatabaseQueryRequest{
+				PropertyFilter: &notionapi.PropertyFilter{
+					Property: "Text",
+					Text: &notionapi.TextFilterCondition{
+						Equals: "text",
+					},
+				},
+			},
+			want: []byte(`{"filter":{"property":"Text","rich_text":{"equals":"text"}}}`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/filter.go
+++ b/filter.go
@@ -8,7 +8,8 @@ type Condition string
 
 type PropertyFilter struct {
 	Property    string                      `json:"property"`
-	Text        *TextFilterCondition        `json:"text,omitempty"`
+	Text        *TextFilterCondition        `json:"rich_text,omitempty"`
+	Title       *TextFilterCondition        `json:"title,omitempty"`
 	Number      *NumberFilterCondition      `json:"number,omitempty"`
 	Checkbox    *CheckboxFilterCondition    `json:"checkbox,omitempty"`
 	Select      *SelectFilterCondition      `json:"select,omitempty"`


### PR DESCRIPTION
# Why
* When "Notion-Version" was "20021-05-13", the following "text" filter was accepted for both Name(title) and other text properties in Notion API.
```go
"filter": {
	"property": "Name",
	"text": {
		"equals": "`+ name + `"
	}
}
```
* However, "Notion-Version" is "2022-02-22", an HTTP status 400 error occurs using the above filter with the error response as blow.
```
body failed validation. Fix one:
body.filter.or should be defined, instead was `undefined`.
body.filter.and should be defined, instead was `undefined`.
body.filter.title should be defined, instead was `undefined`.
body.filter.rich_text should be defined, instead was `undefined`.
body.filter.number should be defined, instead was `undefined`.
...
```
* According to the above error response, "text" is no longer supported. Instead, "title" and "rich_text" should be specified. 

# What
* Changed the JSON property name from "text to "rich_text"
* Added a new property Title in PropertyFilter
* Added test codes for the above updates
