### PR TITLE
Remove omitempty for DateObject on DateProperty

### DIFF
--- a/property.go
+++ b/property.go
@@ -107,7 +107,7 @@ type Option struct {
 type DateProperty struct {
 	ID   ObjectID     `json:"id,omitempty"`
 	Type PropertyType `json:"type,omitempty"`
-	Date *DateObject  `json:"date,omitempty"`
+	Date *DateObject  `json:"date"`
 }
 
 type DateObject struct {


### PR DESCRIPTION
Unfortunately omit empty ending in an API result like something can not be null and must be an empty string error.

Remove the `omitempty` like already used in the workaround in #71 works.