### PR TITLE
Fix File Property

### DIFF
--- a/object.go
+++ b/object.go
@@ -111,7 +111,10 @@ func (d *Date) UnmarshalText(data []byte) error {
 type FileType string
 
 type File struct {
-	Name string `json:"name"`
+	Name     string      `json:"name"`
+	Type     FileType    `json:"type"`
+	File     *FileObject `json:"file,omitempty"`
+	External *FileObject `json:"external,omitempty"`
 }
 
 type FileObject struct {

--- a/page_test.go
+++ b/page_test.go
@@ -95,6 +95,19 @@ func TestPageClient(t *testing.T) {
 								},
 							},
 						},
+						"Some Files": &notionapi.FilesProperty{
+							ID:   "files",
+							Type: "files",
+							Files: []notionapi.File{
+								{
+									Name: "https://google.com",
+									Type: "external",
+									External: &notionapi.FileObject{
+										URL: "https://google.com",
+									},
+								},
+							},
+						},
 						"Name": &notionapi.TitleProperty{
 							ID:   "title",
 							Type: "title",
@@ -264,6 +277,25 @@ func TestPageClient(t *testing.T) {
 								{
 									Type: notionapi.ObjectTypeText,
 									Text: notionapi.Text{Content: "patch"},
+								},
+							},
+						},
+						"Important Files": notionapi.FilesProperty{
+							Type: "files",
+							Files: []notionapi.File{
+								{
+									Type: "external",
+									Name: "https://google.com",
+									External: &notionapi.FileObject{
+										URL: "https://google.com",
+									},
+								},
+								{
+									Type: "external",
+									Name: "https://123.com",
+									External: &notionapi.FileObject{
+										URL: "https://123.com",
+									},
 								},
 							},
 						},

--- a/testdata/page_get.json
+++ b/testdata/page_get.json
@@ -83,6 +83,19 @@
         "href": null
       }]
     },
+    "Some Files": {
+      "id": "file1",
+      "type": "files",
+      "files": [
+        {
+          "name": "https://google.com",
+          "type": "external",
+          "external": {
+            "url": "https://google.com"
+          }
+        }
+      ]
+    },
     "RollupArray": {
       "id": "abcd",
       "type": "rollup",

--- a/testdata/page_get.json
+++ b/testdata/page_get.json
@@ -84,7 +84,7 @@
       }]
     },
     "Some Files": {
-      "id": "file1",
+      "id": "files",
       "type": "files",
       "files": [
         {

--- a/testdata/page_update.json
+++ b/testdata/page_update.json
@@ -68,6 +68,19 @@
         }
       ]
     },
+    "Important Files": {
+      "id": "importantfiles!",
+      "type": "files",
+      "files": [
+        {
+          "name": "https://google.com",
+          "type": "external",
+          "external": {
+            "url": "https://google.com"
+          }
+        }
+      ]
+    },
     "Name": {
       "id": "title",
       "type": "title",


### PR DESCRIPTION
### Issue

It seems that the current `Files` property type was not up to date. In the current version of `notionapi` any update to a page that contains a `Files` property will yield the following error

```
body failed validation. Fix one:
body.properties.Merge Request.files[0].file should be defined, instead was `undefined`.
body.properties.Merge Request.files[0].external should be defined, instead was `undefined`.
```

### Fix
This PR adds the missing fields to the struct such that the request succeeds