### PR TITLE
fix: omitempty user

### DIFF
--- a/user.go
+++ b/user.go
@@ -70,13 +70,13 @@ func (uc *UserClient) List(ctx context.Context, pagination *Pagination) (*UsersL
 type UserType string
 
 type User struct {
-	Object    ObjectType `json:"object"`
+	Object    ObjectType `json:"object,omitempty"`
 	ID        UserID     `json:"id"`
-	Type      UserType   `json:"type"`
-	Name      string     `json:"name"`
-	AvatarURL string     `json:"avatar_url"`
-	Person    *Person    `json:"person"`
-	Bot       *Bot       `json:"bot"`
+	Type      UserType   `json:"type,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	AvatarURL string     `json:"avatar_url,omitempty"`
+	Person    *Person    `json:"person,omitempty"`
+	Bot       *Bot       `json:"bot,omitempty"`
 }
 
 type Person struct {


### PR DESCRIPTION
## What

- Make some fields of the User struct omitempty

## Why

- When creating a Page with a PeopleProperty, an error occurred.
- After applying this fix, that error will no longer occur.

### Code

```go
package main

import (
	"context"

	"github.com/jomei/notionapi"
)

func main() {
	cli := notionapi.NewClient("YOUR_TOKEN")
	_, err := cli.Page.Create(context.Background(), &notionapi.PageCreateRequest{
		Parent: notionapi.Parent{
			Type:       notionapi.ParentTypeDatabaseID,
			DatabaseID: "YOUR_DATABASE_ID",
		},
		Properties: notionapi.Properties{
			"Person": notionapi.PeopleProperty{
				People: []notionapi.User{
					{
						ID: "YOUR_USER_ID",
					},
				},
			},
		},
	})
	if err != nil {
		panic(err)
	}
}
```

### Error

```
body.properties.Person.people[0].object should be `"user"` or `undefined`, instead was `""`.
body.properties.Person.people[0].type should be not present, instead was `""`.
body.properties.Person.people[0].name should be not present, instead was `""`.
body.properties.Person.people[0].avatar_url should be not present, instead was `""`.
body.properties.Person.people[0].person should be defined, instead was `undefined`.
body.properties.Person.people[0].bot should be defined, instead was `undefined`.
```
