### PR TITLE
Added DatabaseID in LinkToPage block object

### DIFF
--- a/block.go
+++ b/block.go
@@ -531,8 +531,9 @@ type LinkToPageBlock struct {
 }
 
 type LinkToPage struct {
-	Type   BlockType `json:"type"`
-	PageID PageID    `json:"page_id"`
+	Type       BlockType  `json:"type"`
+	PageID     PageID     `json:"page_id,omitempty"`
+	DatabaseID DatabaseID `json:"database_id,omitempty"`
 }
 
 type TemplateBlock struct {


### PR DESCRIPTION
LinkToPage block object can point to both i.e. PageID and DatabaseID