### PR TITLE
RichText array object shouldn't have omitempty tag for all type of blocks

### DIFF
--- a/block.go
+++ b/block.go
@@ -243,7 +243,7 @@ type ParagraphBlock struct {
 }
 
 type Paragraph struct {
-	RichText []RichText `json:"rich_text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 	Color    string     `json:"color,omitempty"`
 }
@@ -275,7 +275,7 @@ type CalloutBlock struct {
 }
 
 type Callout struct {
-	RichText []RichText `json:"rich_text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Icon     *Icon      `json:"icon,omitempty"`
 	Children Blocks     `json:"children,omitempty"`
 	Color    string     `json:"color,omitempty"`
@@ -287,7 +287,7 @@ type QuoteBlock struct {
 }
 
 type Quote struct {
-	RichText []RichText `json:"rich_text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 	Color    string     `json:"color,omitempty"`
 }
@@ -319,7 +319,7 @@ type BulletedListItemBlock struct {
 }
 
 type ListItem struct {
-	RichText []RichText `json:"rich_text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 	Color    string     `json:"color,omitempty"`
 }
@@ -335,7 +335,7 @@ type ToDoBlock struct {
 }
 
 type ToDo struct {
-	RichText []RichText `json:"rich_text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 	Checked  bool       `json:"checked"`
 	Color    string     `json:"color,omitempty"`
@@ -347,7 +347,7 @@ type ToggleBlock struct {
 }
 
 type Toggle struct {
-	RichText []RichText `json:"rich_text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 	Color    string     `json:"color,omitempty"`
 }
@@ -398,7 +398,7 @@ type CodeBlock struct {
 }
 
 type Code struct {
-	RichText []RichText `json:"rich_text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Caption  []RichText `json:"caption,omitempty"`
 	Language string     `json:"language"`
 }
@@ -542,7 +542,7 @@ type TemplateBlock struct {
 }
 
 type Template struct {
-	RichText []RichText `json:"rich_text,omitempty"`
+	RichText []RichText `json:"rich_text"`
 	Children Blocks     `json:"children,omitempty"`
 }
 

--- a/block_test.go
+++ b/block_test.go
@@ -492,9 +492,9 @@ func TestBlockUpdateRequest_MarshallJSON(t *testing.T) {
 		{
 			name: "update todo checkbox",
 			req: &notionapi.BlockUpdateRequest{
-				ToDo: &notionapi.ToDo{Checked: false},
+				ToDo: &notionapi.ToDo{Checked: false, RichText: make([]notionapi.RichText, 0)},
 			},
-			want: []byte(`{"to_do":{"checked":false}}`),
+			want: []byte(`{"to_do":{"rich_text":[],"checked":false}}`),
 		},
 	}
 


### PR DESCRIPTION
Block objects having richtext as array should always be provided during append block request else the request throws 400 error.
```
{
    "object": "error",
    "status": 400,
    "code": "validation_error",
    "message": "body failed validation: body.children[0].code.rich_text should be defined, instead was `undefined`."
}
```