### PR TITLE
Adjust StatusProperty `Status` property into `Option`

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -57,6 +57,7 @@ type PropertyFilter struct {
 	Relation    *RelationFilterCondition    `json:"relation,omitempty"`
 	Formula     *FormulaFilterCondition     `json:"formula,omitempty"`
 	Rollup      *RollupFilterCondition      `json:"rollup,omitempty"`
+	Status      *StatusFilterCondition      `json:"status,omitempty"`
 }
 
 func (f PropertyFilter) filter() {}
@@ -162,4 +163,11 @@ type RollupSubfilterCondition struct {
 	Date        *DateFilterCondition        `json:"date,omitempty"`
 	People      *PeopleFilterCondition      `json:"people,omitempty"`
 	Files       *FilesFilterCondition       `json:"files,omitempty"`
+}
+
+type StatusFilterCondition struct {
+	Equals       string `json:"equals,omitempty"`
+	DoesNotEqual string `json:"does_not_equal,omitempty"`
+	IsEmpty      bool   `json:"is_empty,omitempty"`
+	IsNotEmpty   bool   `json:"is_not_empty,omitempty"`
 }

--- a/object.go
+++ b/object.go
@@ -184,9 +184,3 @@ type PropertyID string
 func (pID PropertyID) String() string {
 	return string(pID)
 }
-
-type Status struct {
-	ID    ObjectID `json:"id"`
-	Name  string   `json:"name"`
-	Color Color    `json:"color"`
-}

--- a/property.go
+++ b/property.go
@@ -275,7 +275,7 @@ func (p LastEditedByProperty) GetType() PropertyType {
 type StatusProperty struct {
 	ID     ObjectID     `json:"id,omitempty"`
 	Type   PropertyType `json:"type,omitempty"`
-	Status Status       `json:"status"`
+	Status Option       `json:"status"`
 }
 
 func (p StatusProperty) GetType() PropertyType {


### PR DESCRIPTION
As the [document](https://developers.notion.com/reference/property-object#status-groups), it seems the struct of `Status` is copied from normal `Select`..
<img width="752" alt="image" src="https://user-images.githubusercontent.com/9566402/206886705-0cfb0840-0c09-40c1-81fe-2d362f788b66.png">
Besides there is a JSON parse error in current `Status` property and it will case error when update a `Status` property.