### PR TITLE
Fix index out of bounds panic for Retry-After header

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,12 +142,12 @@ func (c *Client) request(ctx context.Context, method string, urlStr string, quer
 
 		failedAttempts++
 		if failedAttempts == c.maxRetries {
-			return nil, fmt.Errorf("Retry request with 429 response failed after %d retries", failedAttempts)
+			return nil, &RateLimitedError{Message: fmt.Sprintf("Retry request with 429 response failed after %d retries", failedAttempts)}
 		}
 		// https://developers.notion.com/reference/request-limits#rate-limits
 		retryAfterHeader := res.Header["Retry-After"]
 		if len(retryAfterHeader) == 0 {
-			return nil, fmt.Errorf("Retry-After header missing from Notion API response headers for 429 response")
+			return nil, &RateLimitedError{Message: "Retry-After header missing from Notion API response headers for 429 response"}
 		}
 		retryAfter := retryAfterHeader[0]
 

--- a/client.go
+++ b/client.go
@@ -145,7 +145,12 @@ func (c *Client) request(ctx context.Context, method string, urlStr string, quer
 			return nil, fmt.Errorf("Retry request with 429 response failed after %d retries", failedAttempts)
 		}
 		// https://developers.notion.com/reference/request-limits#rate-limits
-		retryAfter := res.Header["Retry-After"][0]
+		retryAfterHeader := res.Header["Retry-After"]
+		if len(retryAfterHeader) == 0 {
+			return nil, fmt.Errorf("Retry-After header missing from Notion API response headers for 429 response")
+		}
+		retryAfter := retryAfterHeader[0]
+
 		waitSeconds, err := strconv.Atoi(retryAfter)
 		if err != nil {
 			break // should not happen

--- a/error.go
+++ b/error.go
@@ -12,3 +12,11 @@ type Error struct {
 func (e *Error) Error() string {
 	return e.Message
 }
+
+type RateLimitedError struct {
+	Message string
+}
+
+func (e *RateLimitedError) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
It appears that sometimes the Notion API does not return a Retry-After response header even when a request gets rate limited, resulting in a panic.