### PR TITLE
Add value to PropertyFilter

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -62,6 +62,11 @@ type PropertyFilter struct {
 
 func (f PropertyFilter) filter() {}
 
+type SearchFilter struct {
+	Value    string `json:"value"`
+	Property string `json:"property"`
+}
+
 type TextFilterCondition struct {
 	Equals         string `json:"equals,omitempty"`
 	DoesNotEqual   string `json:"does_not_equal,omitempty"`

--- a/search.go
+++ b/search.go
@@ -39,11 +39,11 @@ func (sc *SearchClient) Do(ctx context.Context, request *SearchRequest) (*Search
 }
 
 type SearchRequest struct {
-	Query       string      `json:"query,omitempty"`
-	Sort        *SortObject `json:"sort,omitempty"`
-	Filter      interface{} `json:"filter,omitempty"`
-	StartCursor Cursor      `json:"start_cursor,omitempty"`
-	PageSize    int         `json:"page_size,omitempty"`
+	Query       string       `json:"query,omitempty"`
+	Sort        *SortObject  `json:"sort,omitempty"`
+	Filter      SearchFilter `json:"filter,omitempty"`
+	StartCursor Cursor       `json:"start_cursor,omitempty"`
+	PageSize    int          `json:"page_size,omitempty"`
 }
 
 type SearchResponse struct {


### PR DESCRIPTION
I am needing to use the `/search` endpoint to the NotionAPI and was looking at [their docs](https://developers.notion.com/reference/post-search) for the endpoint. It looks like their `filter object` just has 2 attributes: `property` and `value`. By adding a `Value *string` property to the `PropertyFilter` type, you can successfully filter your queries like this —

```golang
desiredObjectType := "page"
response, err := client.Search.Do(context.Background(), &notionapi.SearchRequest{
  Query: "My Desired Page Title",
  Filter: notionapi.PropertyFilter{
    Property: "object",
    Value:    &desiredObjectType,
  },
  StartCursor: "",
  PageSize:    1,
})

response.Results[0] // returns a notionapi.Page object
```