### PR TITLE
Add audio block type

### DIFF
--- a/block.go
+++ b/block.go
@@ -392,6 +392,29 @@ func (i Image) GetURL() string {
 	return ""
 }
 
+type AudioBlock struct {
+	BasicBlock
+	Audio Audio `json:"audio"`
+}
+
+type Audio struct {
+	Caption  []RichText  `json:"caption,omitempty"`
+	Type     FileType    `json:"type"`
+	File     *FileObject `json:"file,omitempty"`
+	External *FileObject `json:"external,omitempty"`
+}
+
+// GetURL returns the external or internal URL depending on the image type.
+func (i Audio) GetURL() string {
+	if i.File != nil {
+		return i.File.URL
+	}
+	if i.External != nil {
+		return i.External.URL
+	}
+	return ""
+}
+
 type CodeBlock struct {
 	BasicBlock
 	Code Code `json:"code"`


### PR DESCRIPTION
Adding audio block type according to [this article](https://developers.notion.com/changelog/users-can-now-add-equation-blocks-and-media-blocks). AFAIK all the official SDKs have such implementation and I need this one in your lib.