### PR TITLE
Support Reading Status Property Configs From Databases

### DIFF
--- a/property_config.go
+++ b/property_config.go
@@ -237,7 +237,7 @@ func (p LastEditedByPropertyConfig) GetType() PropertyConfigType {
 type StatusPropertyConfig struct{
 	ID           ObjectID           `json:"id"`
 	Type         PropertyConfigType `json:"type"`
-	Status		 Select 			`json:"status"`
+	Status       Select             `json:"status"`
 }
 
 func (p StatusPropertyConfig) GetType() PropertyConfigType {

--- a/property_config.go
+++ b/property_config.go
@@ -233,10 +233,14 @@ func (p LastEditedByPropertyConfig) GetType() PropertyConfigType {
 }
 
 //TODO: Status database properties cannot currently be configured via the API and so have no additional configuration within the status property.
-type StatusPropertyConfig struct{}
+type StatusPropertyConfig struct{
+	ID           ObjectID           `json:"id"`
+	Type         PropertyConfigType `json:"type"`
+	Status		 Select 			`json:"status"`
+}
 
 func (p StatusPropertyConfig) GetType() PropertyConfigType {
-	return ""
+	return p.Type
 }
 
 type PropertyConfigs map[string]PropertyConfig

--- a/property_config.go
+++ b/property_config.go
@@ -232,7 +232,8 @@ func (p LastEditedByPropertyConfig) GetType() PropertyConfigType {
 	return p.Type
 }
 
-//TODO: Status database properties cannot currently be configured via the API and so have no additional configuration within the status property.
+// StatusPropertyConfig can only be used to GET property configs from Notion databases.
+// The api currently does not support creating or updating status properties.
 type StatusPropertyConfig struct{
 	ID           ObjectID           `json:"id"`
 	Type         PropertyConfigType `json:"type"`


### PR DESCRIPTION
### Background
The Notion API currently has no or limited support for [creating](https://developers.notion.com/reference/create-a-database) or [updating](https://developers.notion.com/reference/update-a-database) `status` properties. Currently, there is no support for parsing status property configs.

### Proposal
Add support for parsing data into `StatusPropertyConfig` to allow users to work with Notion DB structures.

### Concerns & Limitations
I'm still unclear on the best way to add support for parsing the `status` property type into a StatusPropertyConfig while also preventing the StatusPropertyConfig from being used as an input for  the DatabaseClient.Create() and DatabaseClient.Update() methods.