### PR TITLE
add partial support for unique_id database property

### DIFF
--- a/const.go
+++ b/const.go
@@ -32,6 +32,7 @@ const (
 	PropertyConfigLastEditedTime  PropertyConfigType = "last_edited_time"
 	PropertyConfigLastEditedBy    PropertyConfigType = "last_edited_by"
 	PropertyConfigStatus          PropertyConfigType = "status"
+	PropertyConfigUniqueID        PropertyConfigType = "unique_id"
 )
 
 const (
@@ -56,6 +57,7 @@ const (
 	PropertyTypeLastEditedTime PropertyType = "last_edited_time"
 	PropertyTypeLastEditedBy   PropertyType = "last_edited_by"
 	PropertyTypeStatus         PropertyType = "status"
+	PropertyTypeUniqueID       PropertyType = "unique_id"
 )
 
 const (

--- a/object.go
+++ b/object.go
@@ -1,6 +1,7 @@
 package notionapi
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -186,3 +187,15 @@ func (pID PropertyID) String() string {
 }
 
 type Status = Option
+
+type UniqueID struct {
+	Prefix *string `json:"prefix,omitempty"`
+	Number int     `json:"number"`
+}
+
+func (uID UniqueID) String() string {
+	if uID.Prefix != nil {
+		return fmt.Sprintf("%s-%d", *uID.Prefix, uID.Number)
+	}
+	return fmt.Sprintf("%d", uID.Number)
+}

--- a/property.go
+++ b/property.go
@@ -282,6 +282,16 @@ func (p StatusProperty) GetType() PropertyType {
 	return p.Type
 }
 
+type UniqueIDProperty struct {
+	ID       ObjectID     `json:"id,omitempty"`
+	Type     PropertyType `json:"type,omitempty"`
+	UniqueID UniqueID     `json:"unique_id"`
+}
+
+func (p UniqueIDProperty) GetType() PropertyType {
+	return p.Type
+}
+
 type Properties map[string]Property
 
 func (p *Properties) UnmarshalJSON(data []byte) error {
@@ -370,6 +380,8 @@ func decodeProperty(raw map[string]interface{}) (Property, error) {
 		p = &LastEditedByProperty{}
 	case PropertyTypeStatus:
 		p = &StatusProperty{}
+	case PropertyTypeUniqueID:
+		p = &UniqueIDProperty{}
 	default:
 		return nil, errors.New(fmt.Sprintf("unsupported property type: %s", raw["type"].(string)))
 	}

--- a/property_config.go
+++ b/property_config.go
@@ -232,10 +232,17 @@ func (p LastEditedByPropertyConfig) GetType() PropertyConfigType {
 	return p.Type
 }
 
-//TODO: Status database properties cannot currently be configured via the API and so have no additional configuration within the status property.
+// TODO: Status database properties cannot currently be configured via the API and so have no additional configuration within the status property.
 type StatusPropertyConfig struct{}
 
 func (p StatusPropertyConfig) GetType() PropertyConfigType {
+	return ""
+}
+
+// TODO: API docs don't have this listed yet, not sure of correct structure
+type UniqueIDPropertyConfig struct{}
+
+func (i UniqueIDPropertyConfig) GetType() PropertyConfigType {
 	return ""
 }
 
@@ -302,6 +309,8 @@ func parsePropertyConfigs(raw map[string]interface{}) (PropertyConfigs, error) {
 				p = &LastEditedByPropertyConfig{}
 			case PropertyConfigStatus:
 				p = &StatusPropertyConfig{}
+			case PropertyConfigUniqueID:
+				p = &UniqueIDPropertyConfig{}
 			default:
 
 				return nil, fmt.Errorf("unsupported property type: %s", rawProperty["type"].(string))


### PR DESCRIPTION
https://www.notion.so/help/unique-id it is newly released so their API docs don't have any information yet. Therefore I'm unable to determine the correct implementation for updates, but this works for the read use case - my app started failing with `unsupported property type: unique_id` and this remediates that.

prefix is optional, notion api response looks like either:
```
"unique_id": {
                        "prefix": null,
                        "number": 308
                    }
```
or
```
"unique_id": {
                        "prefix":"FOO",
                        "number": 308
                    }
```