### PR TITLE
fix: new notion relation requires new properties

### DIFF
--- a/const.go
+++ b/const.go
@@ -268,3 +268,8 @@ const (
 	TemplateMentionTypeUser TemplateMentionType = "template_mention_user"
 	TemplateMentionTypeDate TemplateMentionType = "template_mention_date"
 )
+
+const (
+	RelationSingleProperty RelationConfigType = "single_property"
+	RelationDualProperty   RelationConfigType = "dual_property"
+)

--- a/property_config.go
+++ b/property_config.go
@@ -164,10 +164,23 @@ type RelationPropertyConfig struct {
 	Relation RelationConfig     `json:"relation"`
 }
 
+type RelationConfigType string
+
+func (rp RelationConfigType) String() string {
+	return string(rp)
+}
+
+type SingleProperty struct{}
+
+type DualProperty struct{}
+
 type RelationConfig struct {
-	DatabaseID         DatabaseID `json:"database_id"`
-	SyncedPropertyID   PropertyID `json:"synced_property_id"`
-	SyncedPropertyName string     `json:"synced_property_name"`
+	DatabaseID         DatabaseID         `json:"database_id"`
+	SyncedPropertyID   PropertyID         `json:"synced_property_id,omitempty"`
+	SyncedPropertyName string             `json:"synced_property_name,omitempty"`
+	Type               RelationConfigType `json:"type,omitempty"`
+	SingleProperty     *SingleProperty    `json:"single_property,omitempty"`
+	DualProperty       *DualProperty      `json:"dual_property,omitempty"`
 }
 
 func (p RelationPropertyConfig) GetType() PropertyConfigType {


### PR DESCRIPTION
If you try to use this package as it is together with relations it will not work. This because Notion introduced two new fields that seem to have been a breaking change (although they say it was not). [The changelog is available here](https://developers.notion.com/changelog/releasing-notion-version-2022-06-28).

This pull request adds the new fields and add the required constants to be used. A relation then needs to be used as:

```golang
			"Something": notionapi.RelationPropertyConfig{
				Type: notionapi.PropertyConfigTypeRelation,
				Relation: notionapi.RelationConfig{
					DatabaseID:     tables.Venues,
					Type:           notionapi.RelationSingleProperty, // NEW
					SingleProperty: &notionapi.SingleProperty{}, // NEW
				},
			},
```