### PR TITLE
Fix 'token request' authorization header

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -20,7 +20,7 @@ type AuthenticationClient struct {
 //
 // See https://developers.notion.com/reference/create-a-token
 func (cc *AuthenticationClient) CreateToken(ctx context.Context, request *TokenCreateRequest) (*TokenCreateResponse, error) {
-	res, err := cc.apiClient.request(ctx, http.MethodPost, "oauth/token", nil, request)
+	res, err := cc.apiClient.requestImpl(ctx, http.MethodPost, "oauth/token", nil, request, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This endpoint must use the Basic prefix, not the Bearer prefix.

[Notion docs](https://developers.notion.com/reference/create-a-token)

[Issue ref](https://github.com/jomei/notionapi/issues/142)