### PR TITLE
Make color annotation optional / omitempty

### DIFF
--- a/object.go
+++ b/object.go
@@ -95,7 +95,7 @@ type Annotations struct {
 	Strikethrough bool  `json:"strikethrough"`
 	Underline     bool  `json:"underline"`
 	Code          bool  `json:"code"`
-	Color         Color `json:"color"`
+	Color         Color `json:"color,omitempty"`
 }
 
 type RelationObject struct {


### PR DESCRIPTION
If you want to leave the color unchanged when updating a block, the `.color` key should be set to `null` when making requests.