### PR TITLE
Getting Rich Text from various blocks

### DIFF
--- a/block.go
+++ b/block.go
@@ -218,6 +218,7 @@ type Block interface {
 	GetHasChildren() bool
 	GetArchived() bool
 	GetParent() *Parent
+	GetRichText() string
 }
 
 type Blocks []Block
@@ -294,6 +295,98 @@ func (b BasicBlock) GetArchived() bool {
 
 func (b BasicBlock) GetParent() *Parent {
 	return b.Parent
+}
+
+func concatenateRichText(richtext []RichText) string {
+	var result string
+	for _, rt := range richtext {
+		result += rt.PlainText
+	}
+	return result
+}
+
+func (h *Heading1Block) GetRichText() string {
+	return concatenateRichText(h.Heading1.RichText)
+}
+
+func (p *ParagraphBlock) GetRichText() string {
+	return concatenateRichText(p.Paragraph.RichText)
+}
+
+func (h *Heading2Block) GetRichText() string {
+	return concatenateRichText(h.Heading2.RichText)
+}
+
+func (h *Heading3Block) GetRichText() string {
+	return concatenateRichText(h.Heading3.RichText)
+}
+
+func (c *CalloutBlock) GetRichText() string {
+	return concatenateRichText(c.Callout.RichText)
+}
+
+func (q *QuoteBlock) GetRichText() string {
+	return concatenateRichText(q.Quote.RichText)
+}
+
+func (b *BulletedListItemBlock) GetRichText() string {
+	return concatenateRichText(b.BulletedListItem.RichText)
+}
+
+func (n *NumberedListItemBlock) GetRichText() string {
+	return concatenateRichText(n.NumberedListItem.RichText)
+}
+
+func (t *ToDoBlock) GetRichText() string {
+	return concatenateRichText(t.ToDo.RichText)
+}
+
+func (b *ToggleBlock) GetRichText() string {
+	return concatenateRichText(b.Toggle.RichText)
+}
+
+func (b *EmbedBlock) GetRichText() string {
+	return concatenateRichText(b.Embed.Caption)
+}
+
+func (b *ImageBlock) GetRichText() string {
+	return concatenateRichText(b.Image.Caption)
+}
+
+func (b *AudioBlock) GetRichText() string {
+	return concatenateRichText(b.Audio.Caption)
+}
+
+func (b *VideoBlock) GetRichText() string {
+	return concatenateRichText(b.Video.Caption)
+}
+
+func (b *FileBlock) GetRichText() string {
+	return concatenateRichText(b.File.Caption)
+}
+
+func (b *PdfBlock) GetRichText() string {
+	return concatenateRichText(b.Pdf.Caption)
+}
+
+func (b *BookmarkBlock) GetRichText() string {
+	return concatenateRichText(b.Bookmark.Caption)
+}
+
+func (b *TemplateBlock) GetRichText() string {
+	return concatenateRichText(b.Template.RichText)
+}
+
+func (b *LinkPreviewBlock) GetRichText() string {
+	return b.LinkPreview.URL
+}
+
+func (b *EquationBlock) GetRichText() string {
+	return b.Equation.Expression
+}
+
+func (b *BasicBlock) GetRichText() string {
+	return "No rich text of a basic block."
 }
 
 var _ Block = (*BasicBlock)(nil)

--- a/block.go
+++ b/block.go
@@ -306,75 +306,75 @@ func ConcatenateRichTextString(richtext []RichText) string {
 }
 
 func (h *Heading1Block) GetRichTextString() string {
-	return concatenateRichText(h.Heading1.RichText)
+	return ConcatenateRichTextString(h.Heading1.RichText)
 }
 
 func (p *ParagraphBlock) GetRichTextString() string {
-	return concatenateRichText(p.Paragraph.RichText)
+	return ConcatenateRichTextString(p.Paragraph.RichText)
 }
 
 func (h *Heading2Block) GetRichTextString() string {
-	return concatenateRichText(h.Heading2.RichText)
+	return ConcatenateRichTextString(h.Heading2.RichText)
 }
 
 func (h *Heading3Block) GetRichTextString() string {
-	return concatenateRichText(h.Heading3.RichText)
+	return ConcatenateRichTextString(h.Heading3.RichText)
 }
 
 func (c *CalloutBlock) GetRichTextString() string {
-	return concatenateRichText(c.Callout.RichText)
+	return ConcatenateRichTextString(c.Callout.RichText)
 }
 
 func (q *QuoteBlock) GetRichTextString() string {
-	return concatenateRichText(q.Quote.RichText)
+	return ConcatenateRichTextString(q.Quote.RichText)
 }
 
 func (b *BulletedListItemBlock) GetRichTextString() string {
-	return concatenateRichText(b.BulletedListItem.RichText)
+	return ConcatenateRichTextString(b.BulletedListItem.RichText)
 }
 
 func (n *NumberedListItemBlock) GetRichTextString() string {
-	return concatenateRichText(n.NumberedListItem.RichText)
+	return ConcatenateRichTextString(n.NumberedListItem.RichText)
 }
 
 func (t *ToDoBlock) GetRichTextString() string {
-	return concatenateRichText(t.ToDo.RichText)
+	return ConcatenateRichTextString(t.ToDo.RichText)
 }
 
 func (b *ToggleBlock) GetRichTextString() string {
-	return concatenateRichText(b.Toggle.RichText)
+	return ConcatenateRichTextString(b.Toggle.RichText)
 }
 
 func (b *EmbedBlock) GetRichTextString() string {
-	return concatenateRichText(b.Embed.Caption)
+	return ConcatenateRichTextString(b.Embed.Caption)
 }
 
 func (b *ImageBlock) GetRichTextString() string {
-	return concatenateRichText(b.Image.Caption)
+	return ConcatenateRichTextString(b.Image.Caption)
 }
 
 func (b *AudioBlock) GetRichTextString() string {
-	return concatenateRichText(b.Audio.Caption)
+	return ConcatenateRichTextString(b.Audio.Caption)
 }
 
 func (b *VideoBlock) GetRichTextString() string {
-	return concatenateRichText(b.Video.Caption)
+	return ConcatenateRichTextString(b.Video.Caption)
 }
 
 func (b *FileBlock) GetRichTextString() string {
-	return concatenateRichText(b.File.Caption)
+	return ConcatenateRichTextString(b.File.Caption)
 }
 
 func (b *PdfBlock) GetRichTextString() string {
-	return concatenateRichText(b.Pdf.Caption)
+	return ConcatenateRichTextString(b.Pdf.Caption)
 }
 
 func (b *BookmarkBlock) GetRichTextString() string {
-	return concatenateRichText(b.Bookmark.Caption)
+	return ConcatenateRichTextString(b.Bookmark.Caption)
 }
 
 func (b *TemplateBlock) GetRichTextString() string {
-	return concatenateRichText(b.Template.RichText)
+	return ConcatenateRichTextString(b.Template.RichText)
 }
 
 func (b *LinkPreviewBlock) GetRichTextString() string {

--- a/block.go
+++ b/block.go
@@ -218,7 +218,7 @@ type Block interface {
 	GetHasChildren() bool
 	GetArchived() bool
 	GetParent() *Parent
-	GetRichText() string
+	GetRichTextString() string
 }
 
 type Blocks []Block
@@ -297,7 +297,7 @@ func (b BasicBlock) GetParent() *Parent {
 	return b.Parent
 }
 
-func concatenateRichText(richtext []RichText) string {
+func ConcatenateRichTextString(richtext []RichText) string {
 	var result string
 	for _, rt := range richtext {
 		result += rt.PlainText
@@ -305,87 +305,87 @@ func concatenateRichText(richtext []RichText) string {
 	return result
 }
 
-func (h *Heading1Block) GetRichText() string {
+func (h *Heading1Block) GetRichTextString() string {
 	return concatenateRichText(h.Heading1.RichText)
 }
 
-func (p *ParagraphBlock) GetRichText() string {
+func (p *ParagraphBlock) GetRichTextString() string {
 	return concatenateRichText(p.Paragraph.RichText)
 }
 
-func (h *Heading2Block) GetRichText() string {
+func (h *Heading2Block) GetRichTextString() string {
 	return concatenateRichText(h.Heading2.RichText)
 }
 
-func (h *Heading3Block) GetRichText() string {
+func (h *Heading3Block) GetRichTextString() string {
 	return concatenateRichText(h.Heading3.RichText)
 }
 
-func (c *CalloutBlock) GetRichText() string {
+func (c *CalloutBlock) GetRichTextString() string {
 	return concatenateRichText(c.Callout.RichText)
 }
 
-func (q *QuoteBlock) GetRichText() string {
+func (q *QuoteBlock) GetRichTextString() string {
 	return concatenateRichText(q.Quote.RichText)
 }
 
-func (b *BulletedListItemBlock) GetRichText() string {
+func (b *BulletedListItemBlock) GetRichTextString() string {
 	return concatenateRichText(b.BulletedListItem.RichText)
 }
 
-func (n *NumberedListItemBlock) GetRichText() string {
+func (n *NumberedListItemBlock) GetRichTextString() string {
 	return concatenateRichText(n.NumberedListItem.RichText)
 }
 
-func (t *ToDoBlock) GetRichText() string {
+func (t *ToDoBlock) GetRichTextString() string {
 	return concatenateRichText(t.ToDo.RichText)
 }
 
-func (b *ToggleBlock) GetRichText() string {
+func (b *ToggleBlock) GetRichTextString() string {
 	return concatenateRichText(b.Toggle.RichText)
 }
 
-func (b *EmbedBlock) GetRichText() string {
+func (b *EmbedBlock) GetRichTextString() string {
 	return concatenateRichText(b.Embed.Caption)
 }
 
-func (b *ImageBlock) GetRichText() string {
+func (b *ImageBlock) GetRichTextString() string {
 	return concatenateRichText(b.Image.Caption)
 }
 
-func (b *AudioBlock) GetRichText() string {
+func (b *AudioBlock) GetRichTextString() string {
 	return concatenateRichText(b.Audio.Caption)
 }
 
-func (b *VideoBlock) GetRichText() string {
+func (b *VideoBlock) GetRichTextString() string {
 	return concatenateRichText(b.Video.Caption)
 }
 
-func (b *FileBlock) GetRichText() string {
+func (b *FileBlock) GetRichTextString() string {
 	return concatenateRichText(b.File.Caption)
 }
 
-func (b *PdfBlock) GetRichText() string {
+func (b *PdfBlock) GetRichTextString() string {
 	return concatenateRichText(b.Pdf.Caption)
 }
 
-func (b *BookmarkBlock) GetRichText() string {
+func (b *BookmarkBlock) GetRichTextString() string {
 	return concatenateRichText(b.Bookmark.Caption)
 }
 
-func (b *TemplateBlock) GetRichText() string {
+func (b *TemplateBlock) GetRichTextString() string {
 	return concatenateRichText(b.Template.RichText)
 }
 
-func (b *LinkPreviewBlock) GetRichText() string {
+func (b *LinkPreviewBlock) GetRichTextString() string {
 	return b.LinkPreview.URL
 }
 
-func (b *EquationBlock) GetRichText() string {
+func (b *EquationBlock) GetRichTextString() string {
 	return b.Equation.Expression
 }
 
-func (b *BasicBlock) GetRichText() string {
+func (b *BasicBlock) GetRichTextString() string {
 	return "No rich text of a basic block."
 }
 

--- a/block.go
+++ b/block.go
@@ -297,7 +297,7 @@ func (b BasicBlock) GetParent() *Parent {
 	return b.Parent
 }
 
-func ConcatenateRichTextString(richtext []RichText) string {
+func concatenateRichTextString(richtext []RichText) string {
 	var result string
 	for _, rt := range richtext {
 		result += rt.PlainText
@@ -306,75 +306,75 @@ func ConcatenateRichTextString(richtext []RichText) string {
 }
 
 func (h *Heading1Block) GetRichTextString() string {
-	return ConcatenateRichTextString(h.Heading1.RichText)
+	return concatenateRichTextString(h.Heading1.RichText)
 }
 
 func (p *ParagraphBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(p.Paragraph.RichText)
+	return concatenateRichTextString(p.Paragraph.RichText)
 }
 
 func (h *Heading2Block) GetRichTextString() string {
-	return ConcatenateRichTextString(h.Heading2.RichText)
+	return concatenateRichTextString(h.Heading2.RichText)
 }
 
 func (h *Heading3Block) GetRichTextString() string {
-	return ConcatenateRichTextString(h.Heading3.RichText)
+	return concatenateRichTextString(h.Heading3.RichText)
 }
 
 func (c *CalloutBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(c.Callout.RichText)
+	return concatenateRichTextString(c.Callout.RichText)
 }
 
 func (q *QuoteBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(q.Quote.RichText)
+	return concatenateRichTextString(q.Quote.RichText)
 }
 
 func (b *BulletedListItemBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.BulletedListItem.RichText)
+	return concatenateRichTextString(b.BulletedListItem.RichText)
 }
 
 func (n *NumberedListItemBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(n.NumberedListItem.RichText)
+	return concatenateRichTextString(n.NumberedListItem.RichText)
 }
 
 func (t *ToDoBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(t.ToDo.RichText)
+	return concatenateRichTextString(t.ToDo.RichText)
 }
 
 func (b *ToggleBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.Toggle.RichText)
+	return concatenateRichTextString(b.Toggle.RichText)
 }
 
 func (b *EmbedBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.Embed.Caption)
+	return concatenateRichTextString(b.Embed.Caption)
 }
 
 func (b *ImageBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.Image.Caption)
+	return concatenateRichTextString(b.Image.Caption)
 }
 
 func (b *AudioBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.Audio.Caption)
+	return concatenateRichTextString(b.Audio.Caption)
 }
 
 func (b *VideoBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.Video.Caption)
+	return concatenateRichTextString(b.Video.Caption)
 }
 
 func (b *FileBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.File.Caption)
+	return concatenateRichTextString(b.File.Caption)
 }
 
 func (b *PdfBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.Pdf.Caption)
+	return concatenateRichTextString(b.Pdf.Caption)
 }
 
 func (b *BookmarkBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.Bookmark.Caption)
+	return concatenateRichTextString(b.Bookmark.Caption)
 }
 
 func (b *TemplateBlock) GetRichTextString() string {
-	return ConcatenateRichTextString(b.Template.RichText)
+	return concatenateRichTextString(b.Template.RichText)
 }
 
 func (b *LinkPreviewBlock) GetRichTextString() string {


### PR DESCRIPTION
As the issue #165 has mentioned, getting rich text is really messy from different blocks. He has suggested creating a new interface but I dont think it was necessary, while we can use the "**Block**" interface already.

![image](https://github.com/jomei/notionapi/assets/64064136/871863af-d729-407e-8f56-f63b985cf418) (used the library to test)
![image](https://github.com/jomei/notionapi/assets/64064136/1c647546-1178-407e-a2b8-838c27abb8fd) (result)

Basically, you can get the rich texts immediately with just one function now instead of calling lots of switch cases. It still has room to be improved, im open for reviews and so on. 

I tried to grasp as much as I can from the codebase as knowledge, but I may probably have missed some parts, so we can work on them if there are loopholes after you review my code.

**I've destroyed the secret token so the screenshot is safe. fyi.**

Waiting for an answer, thanks.