### PR TITLE
Validation error when trying to update an image and PDF block

### DIFF
--- a/block.go
+++ b/block.go
@@ -438,7 +438,7 @@ type ImageBlock struct {
 
 type Image struct {
 	Caption  []RichText  `json:"caption,omitempty"`
-	Type     FileType    `json:"type"`
+	Type     FileType    `json:"type,omitempty"`
 	File     *FileObject `json:"file,omitempty"`
 	External *FileObject `json:"external,omitempty"`
 }
@@ -519,7 +519,7 @@ type PdfBlock struct {
 
 type Pdf struct {
 	Caption  []RichText  `json:"caption,omitempty"`
-	Type     FileType    `json:"type"`
+	Type     FileType    `json:"type,omitempty"`
 	File     *FileObject `json:"file,omitempty"`
 	External *FileObject `json:"external,omitempty"`
 }


### PR DESCRIPTION
As the issue #169 mentioned, we can't update block pdf and image since ```type``` is sent as an empty string.
I added ```omitempty``` in FileType