### PR TITLE
fix: get `GetType()` for unique ID

### DIFF
--- a/property_config.go
+++ b/property_config.go
@@ -359,7 +359,7 @@ type UniqueIDConfig struct {
 }
 
 func (p UniqueIDPropertyConfig) GetType() PropertyConfigType {
-	return ""
+	return p.Type
 }
 
 func (p UniqueIDPropertyConfig) GetID() PropertyID {


### PR DESCRIPTION
Fix the GetType() functionality for the unique ID.