### PR TITLE
BlockTypeTableBlock -> BlockTypeTable; BlockTypeTableRowBlock -> Bloc…

### DIFF
--- a/block.go
+++ b/block.go
@@ -834,9 +834,9 @@ func decodeBlock(raw map[string]interface{}) (Block, error) {
 		b = &TemplateBlock{}
 	case BlockTypeSyncedBlock:
 		b = &SyncedBlock{}
-	case BlockTypeTableBlock:
+	case BlockTypeTable:
 		b = &TableBlock{}
-	case BlockTypeTableRowBlock:
+	case BlockTypeTableRow:
 		b = &TableRowBlock{}
 
 	case BlockTypeUnsupported:

--- a/const.go
+++ b/const.go
@@ -237,8 +237,8 @@ const (
 	BlockTypeLinkToPage      BlockType = "link_to_page"
 	BlockTypeTemplate        BlockType = "template"
 	BlockTypeSyncedBlock     BlockType = "synced_block"
-	BlockTypeTableBlock      BlockType = "table"
-	BlockTypeTableRowBlock   BlockType = "table_row"
+	BlockTypeTable           BlockType = "table"
+	BlockTypeTableRow        BlockType = "table_row"
 	BlockTypeUnsupported     BlockType = "unsupported"
 )
 


### PR DESCRIPTION
Similar to https://github.com/jomei/notionapi/pull/182

Let's have all BlockType constants to be suffixed with `Something` but not `SomethingBlock` suffix.

BlockTypeTable, BlockTypeTableRow