### PR TITLE
hotfix: RichText.Type has its own enum

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -84,7 +84,7 @@ func TestBlockClient(t *testing.T) {
 								IsToggleable bool                 `json:"is_toggleable,omitempty"`
 							}{[]notionapi.RichText{
 								{
-									Type: notionapi.ObjectTypeText,
+									Type: notionapi.RichTextTypeText,
 									Text: &notionapi.Text{Content: "Hello"},
 								},
 							}, nil, "", false,
@@ -114,7 +114,7 @@ func TestBlockClient(t *testing.T) {
 							Paragraph: notionapi.Paragraph{
 								RichText: []notionapi.RichText{
 									{
-										Type: notionapi.ObjectTypeText,
+										Type: notionapi.RichTextTypeText,
 										Text: &notionapi.Text{Content: "AAAAAA"},
 										Annotations: &notionapi.Annotations{
 											Bold:  true,
@@ -259,7 +259,7 @@ func TestBlockClient(t *testing.T) {
 					Paragraph: notionapi.Paragraph{
 						RichText: []notionapi.RichText{
 							{
-								Type: notionapi.ObjectTypeText,
+								Type: notionapi.RichTextTypeText,
 								Text: &notionapi.Text{
 									Content: "Hello",
 								},

--- a/comment_test.go
+++ b/comment_test.go
@@ -52,7 +52,7 @@ func TestCommentClient(t *testing.T) {
 							},
 							RichText: []notionapi.RichText{
 								{
-									Type: notionapi.ObjectTypeText,
+									Type: notionapi.RichTextTypeText,
 									Text: &notionapi.Text{Content: "content"},
 								},
 							},
@@ -70,7 +70,7 @@ func TestCommentClient(t *testing.T) {
 							},
 							RichText: []notionapi.RichText{
 								{
-									Type: notionapi.ObjectTypeText,
+									Type: notionapi.RichTextTypeText,
 									Text: &notionapi.Text{Content: "content"},
 								},
 							},
@@ -122,7 +122,7 @@ func TestCommentClient(t *testing.T) {
 					},
 					RichText: []notionapi.RichText{
 						{
-							Type: notionapi.ObjectTypeText,
+							Type: notionapi.RichTextTypeText,
 							Text: &notionapi.Text{Content: "Hello world"},
 						},
 					},
@@ -140,7 +140,7 @@ func TestCommentClient(t *testing.T) {
 					},
 					RichText: []notionapi.RichText{
 						{
-							Type: notionapi.ObjectTypeText,
+							Type: notionapi.RichTextTypeText,
 							Text: &notionapi.Text{Content: "Hello world"},
 						},
 					},

--- a/const.go
+++ b/const.go
@@ -261,6 +261,12 @@ const (
 )
 
 const (
+	RichTextTypeText     RichTextType = "text"
+	RichTextTypeMention  RichTextType = "mention"
+	RichTextTypeEquation RichTextType = "equation"
+)
+
+const (
 	MentionTypeDatabase        MentionType = "database"
 	MentionTypePage            MentionType = "page"
 	MentionTypeUser            MentionType = "user"

--- a/database_test.go
+++ b/database_test.go
@@ -47,7 +47,7 @@ func TestDatabaseClient(t *testing.T) {
 					LastEditedBy:   user,
 					Title: []notionapi.RichText{
 						{
-							Type:        notionapi.ObjectTypeText,
+							Type:        notionapi.RichTextTypeText,
 							Text:        &notionapi.Text{Content: "Test Database"},
 							Annotations: &notionapi.Annotations{Color: "default"},
 							PlainText:   "Test Database",
@@ -179,7 +179,7 @@ func TestDatabaseClient(t *testing.T) {
 				request: &notionapi.DatabaseUpdateRequest{
 					Title: []notionapi.RichText{
 						{
-							Type: notionapi.ObjectTypeText,
+							Type: notionapi.RichTextTypeText,
 							Text: &notionapi.Text{Content: "patch"},
 						},
 					},
@@ -202,7 +202,7 @@ func TestDatabaseClient(t *testing.T) {
 					},
 					Title: []notionapi.RichText{
 						{
-							Type: notionapi.ObjectTypeText,
+							Type: notionapi.RichTextTypeText,
 							Text: &notionapi.Text{Content: "patch"},
 						},
 					},
@@ -262,7 +262,7 @@ func TestDatabaseClient(t *testing.T) {
 					},
 					Title: []notionapi.RichText{
 						{
-							Type: notionapi.ObjectTypeText,
+							Type: notionapi.RichTextTypeText,
 							Text: &notionapi.Text{Content: "Grocery List"},
 						},
 					},
@@ -286,7 +286,7 @@ func TestDatabaseClient(t *testing.T) {
 					},
 					Title: []notionapi.RichText{
 						{
-							Type:        notionapi.ObjectTypeText,
+							Type:        notionapi.RichTextTypeText,
 							Text:        &notionapi.Text{Content: "Grocery List"},
 							PlainText:   "Grocery List",
 							Annotations: &notionapi.Annotations{Color: notionapi.ColorDefault},
@@ -318,7 +318,7 @@ func TestDatabaseClient(t *testing.T) {
 					},
 					Title: []notionapi.RichText{
 						{
-							Type: notionapi.ObjectTypeText,
+							Type: notionapi.RichTextTypeText,
 							Text: &notionapi.Text{Content: "Grocery List"},
 						},
 					},
@@ -342,7 +342,7 @@ func TestDatabaseClient(t *testing.T) {
 					},
 					Title: []notionapi.RichText{
 						{
-							Type:        notionapi.ObjectTypeText,
+							Type:        notionapi.RichTextTypeText,
 							Text:        &notionapi.Text{Content: "Grocery List"},
 							PlainText:   "Grocery List",
 							Annotations: &notionapi.Annotations{Color: notionapi.ColorDefault},
@@ -374,7 +374,7 @@ func TestDatabaseClient(t *testing.T) {
 					},
 					Title: []notionapi.RichText{
 						{
-							Type: notionapi.ObjectTypeText,
+							Type: notionapi.RichTextTypeText,
 							Text: &notionapi.Text{Content: "Grocery List"},
 						},
 					},
@@ -398,7 +398,7 @@ func TestDatabaseClient(t *testing.T) {
 					},
 					Title: []notionapi.RichText{
 						{
-							Type:        notionapi.ObjectTypeText,
+							Type:        notionapi.RichTextTypeText,
 							Text:        &notionapi.Text{Content: "Grocery List"},
 							PlainText:   "Grocery List",
 							Annotations: &notionapi.Annotations{Color: notionapi.ColorDefault},

--- a/object.go
+++ b/object.go
@@ -35,6 +35,12 @@ func (c Color) MarshalText() ([]byte, error) {
 	return []byte(c), nil
 }
 
+type RichTextType string
+
+func (rtType RichTextType) String() string {
+	return string(rtType)
+}
+
 type MentionType string
 
 func (mType MentionType) String() string {
@@ -71,7 +77,7 @@ type Mention struct {
 }
 
 type RichText struct {
-	Type        ObjectType   `json:"type,omitempty"`
+	Type        RichTextType `json:"type,omitempty"`
 	Text        *Text        `json:"text,omitempty"`
 	Mention     *Mention     `json:"mention,omitempty"`
 	Equation    *Equation    `json:"equation,omitempty"`

--- a/page_test.go
+++ b/page_test.go
@@ -275,7 +275,7 @@ func TestPageClient(t *testing.T) {
 							Type: notionapi.PropertyTypeRichText,
 							RichText: []notionapi.RichText{
 								{
-									Type: notionapi.ObjectTypeText,
+									Type: notionapi.RichTextTypeText,
 									Text: &notionapi.Text{Content: "patch"},
 								},
 							},
@@ -386,7 +386,7 @@ func TestPageCreateRequest_MarshallJSON(t *testing.T) {
 					"Summary": notionapi.TextProperty{
 						Text: []notionapi.RichText{
 							{
-								Type: notionapi.ObjectTypeText,
+								Type: notionapi.RichTextTypeText,
 								Text: &notionapi.Text{
 									Content: "Some content",
 								},
@@ -435,7 +435,7 @@ func TestPageCreateRequest_MarshallJSON(t *testing.T) {
 					"Summary": notionapi.TextProperty{
 						Text: []notionapi.RichText{
 							{
-								Type: notionapi.ObjectTypeText,
+								Type: notionapi.RichTextTypeText,
 								Text: &notionapi.Text{
 									Content: "Some content",
 								},
@@ -460,7 +460,7 @@ func TestPageCreateRequest_MarshallJSON(t *testing.T) {
 						Heading2: notionapi.Heading{
 							RichText: []notionapi.RichText{
 								{
-									Type: notionapi.ObjectTypeText,
+									Type: notionapi.RichTextTypeText,
 									Text: &notionapi.Text{Content: "Lacinato"},
 								},
 							},


### PR DESCRIPTION
RichText object had type of ObjectType that is a different enum. RichText's types are simpler: text, mention, equation.

Reference: https://developers.notion.com/reference/rich-text