### PR TITLE
feat: set option.name as omitempty

### DIFF
--- a/property.go
+++ b/property.go
@@ -123,7 +123,7 @@ func (p MultiSelectProperty) GetType() PropertyType {
 
 type Option struct {
 	ID    PropertyID `json:"id,omitempty"`
-	Name  string     `json:"name"`
+	Name  string     `json:"name,omitempty"`
 	Color Color      `json:"color,omitempty"`
 }
 


### PR DESCRIPTION
Hello there! 

Thanks a lot for this package, we are using it in the company I am working for for some automations. One issue we encountered is the name is not as `omitempty`, creating this kind of errors when we want to create a property using only its ID and not having its name.

```
Fail to create notion page: body failed validation. body.properties.XXX.select.name should be populated or undefined, instead was `\"\"`.
```

Having the `name` property as `omitempty` would indeed populate the field as `undefined`.