### PR TITLE
Use `strings.Builder` to form rich text string

### DIFF
--- a/block.go
+++ b/block.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -297,11 +298,11 @@ func (b BasicBlock) GetParent() *Parent {
 	return b.Parent
 }
 func concatenateRichText(richtext []RichText) string {
-	var result string
+	var text strings.Builder
 	for _, rt := range richtext {
-		result += rt.PlainText
+		text.WriteString(rt.PlainText)
 	}
-	return result
+	return text.String()
 }
 
 func (h Heading1Block) GetRichTextString() string {
@@ -385,7 +386,7 @@ func (b EquationBlock) GetRichTextString() string {
 }
 
 func (b BasicBlock) GetRichTextString() string {
-	return "No rich text of a basic block."
+	return ""
 }
 
 var _ Block = (*BasicBlock)(nil)

--- a/block_test.go
+++ b/block_test.go
@@ -3,8 +3,8 @@ package notionapi_test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -469,7 +469,7 @@ func TestBlockArrayUnmarshal(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				data, err := ioutil.ReadFile(tt.filePath)
+				data, err := os.ReadFile(tt.filePath)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
Rather than creating a new immutable string per additional element, this reuses and grows an internal buffer.